### PR TITLE
Fix SignFile and VerifyESP

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -150,8 +150,8 @@ func SignFile(key, cert, file, output, checksum string) []byte {
 		os.Exit(1)
 	}
 
-	// Lets check if we have signed it already...
-	if VerifyFile(cert, file) || ChecksumFile(file) == checksum {
+	// Let's check if we have signed it already AND the original file hasn't changed
+	if VerifyFile(cert, output) && ChecksumFile(file) == checksum {
 		msg.Printf("%s has been signed...", file)
 		return []byte{}
 	}

--- a/sbctl.go
+++ b/sbctl.go
@@ -51,7 +51,11 @@ func VerifyESP() {
 	for _, file := range files {
 		normalized := strings.Join(strings.Split(file.OutputFile, "/")[2:], "/")
 		checked[normalized] = true
-		if VerifyFile(DBCert, file.OutputFile) {
+
+		// Check output file exists before checking if it's signed
+		if _, err := os.Stat(file.OutputFile); os.IsNotExist(err) {
+			warning2.Printf("%s does not exist\n", file.OutputFile)
+		} else if VerifyFile(DBCert, file.OutputFile) {
 			msg2.Printf("%s is signed\n", file.OutputFile)
 		} else {
 			warning2.Printf("%s is not signed\n", file.OutputFile)


### PR DESCRIPTION
SignFile was performing the wrong verification to see if it could skip signing a file, and VerifyESP was printing the wrong error message when the output file couldn't be found.