### PR TITLE
Implement optional signing of bundles on creation

### DIFF
--- a/cmd/sbctl/main.go
+++ b/cmd/sbctl/main.go
@@ -83,7 +83,7 @@ func signAllCmd() *cobra.Command {
 			out_sign := false
 
 			if generate {
-				out_bundle = sbctl.GenerateAllBundles()
+				out_bundle = sbctl.GenerateAllBundles(true)
 			}
 
 			files := sbctl.ReadFileDatabase(sbctl.DBPath)
@@ -234,7 +234,7 @@ func generateBundlesCmd() *cobra.Command {
 		Use:   "generate-bundles",
 		Short: "Generate all EFI stub bundles",
 		Run: func(cmd *cobra.Command, args []string) {
-			sbctl.GenerateAllBundles()
+			sbctl.GenerateAllBundles(sign)
 		},
 	}
 	f := cmd.Flags()

--- a/sbctl.go
+++ b/sbctl.go
@@ -245,19 +245,33 @@ func CreateBundle(bundle Bundle) error {
 	return nil
 }
 
-func GenerateAllBundles() error {
+func GenerateAllBundles(sign bool) error {
 	msg.Println("Generating EFI bundles....")
 	bundles := ReadBundleDatabase(BundleDBPath)
-	out := true
+	out_create := true
+	out_sign := true
 	for _, bundle := range bundles {
 		err := CreateBundle(*bundle)
 		if err != nil {
-			out = false
+			out_create = false
+			continue
+		}
+
+		if sign {
+			file := bundle.Output
+			err = SignFile(DBKey, DBCert, file, file, "")
+			if err != nil {
+				out_sign = false
+			}
 		}
 	}
 
-	if !out {
+	if !out_create {
 		return PrintGenerateError(err, "Error generating EFI bundles")
+	}
+
+	if !out_sign {
+		return PrintGenerateError(err, "Error signing EFI bundles")
 	}
 
 	return nil


### PR DESCRIPTION
...and sign them by default when generated in a `sign-all` call.

Fixes #26 .

Copy-paste of what I said in the issue:


I spotted a [lonely, unused flag](https://github.com/Foxboron/sbctl/blame/fda4f2c1efd801cd04fb52923afcdb34baa42369/cmd/sbctl/main.go#L232) called `sign` in `generateBundlesCmd()` and took the liberty to give it some purpose and make it actually sign the bundles after creation. ;)

This presents us with an easy solution:
Thanks to the `sign` flag, the bundles are only signed optionally on creation, which is good. We could of course introduce another flag, however in the situation where someone calls `sign-all --generate`, I think it's fair to assume that he/she also wants the generated bundles to be signed, considering the very name of that command. So whenever we call `GenerateAllBundles` from `signAllCmd`, we just pass `true` along with it, and that does the trick.