### PR TITLE
Fix lint step in CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
          - uses: actions/checkout@v1
          - run: make
          - run: make test
-         - run: make deps lint
+         - run: GOBIN=/usr/bin make deps lint
    void:
       runs-on: ubuntu-latest
       container: voidlinux/voidlinux-musl
@@ -21,4 +21,4 @@ jobs:
          - uses: actions/checkout@v1
          - run: make
          - run: make test
-         - run: make deps lint
+         - run: GOBIN=/usr/bin make deps lint


### PR DESCRIPTION
Set GOBIN during `make deps` so staticcheck is installed directly in a
directory already in PATH.