### PR TITLE
keys: sbkeysync can have "Permissiond denide" errors

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -130,6 +130,10 @@ func SBKeySync(dir string) bool {
 			fmt.Println(stdout)
 			return false
 		}
+		if strings.Contains(line, "Permission denied") {
+			fmt.Println(stdout)
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
Signed-off-by: Morten Linderud <morten@linderud.pw>