### PR TITLE
sbctl: Check for immutable files before sbkeysync

### DIFF
--- a/chattr.go
+++ b/chattr.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package sbctl
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	// There is a logic to these but I don't care to implement it all.
+	// If you do, chase them from linux/fs.h
+	_FS_IOC_GETFLAGS = uintptr(0x80086601)
+	_FS_IOC_SETFLAGS = uintptr(0x40086602)
+)
+
+const (
+	// from /usr/include/linux/fs.h
+	FS_SECRM_FL        = 0x00000001 /* Secure deletion */
+	FS_UNRM_FL         = 0x00000002 /* Undelete */
+	FS_COMPR_FL        = 0x00000004 /* Compress file */
+	FS_SYNC_FL         = 0x00000008 /* Synchronous updates */
+	FS_IMMUTABLE_FL    = 0x00000010 /* Immutable file */
+	FS_APPEND_FL       = 0x00000020 /* writes to file may only append */
+	FS_NODUMP_FL       = 0x00000040 /* do not dump file */
+	FS_NOATIME_FL      = 0x00000080 /* do not update atime */
+	FS_DIRTY_FL        = 0x00000100
+	FS_COMPRBLK_FL     = 0x00000200 /* One or more compressed clusters */
+	FS_NOCOMP_FL       = 0x00000400 /* Don't compress */
+	FS_ECOMPR_FL       = 0x00000800 /* Compression error */
+	FS_BTREE_FL        = 0x00001000 /* btree format dir */
+	FS_INDEX_FL        = 0x00001000 /* hash-indexed directory */
+	FS_IMAGIC_FL       = 0x00002000 /* AFS directory */
+	FS_JOURNAL_DATA_FL = 0x00004000 /* Reserved for ext3 */
+	FS_NOTAIL_FL       = 0x00008000 /* file tail should not be merged */
+	FS_DIRSYNC_FL      = 0x00010000 /* dirsync behaviour (directories only) */
+	FS_TOPDIR_FL       = 0x00020000 /* Top of directory hierarchies*/
+	FS_EXTENT_FL       = 0x00080000 /* Extents */
+	FS_DIRECTIO_FL     = 0x00100000 /* Use direct i/o */
+	FS_NOCOW_FL        = 0x00800000 /* Do not cow file */
+	FS_PROJINHERIT_FL  = 0x20000000 /* Create with parents projid */
+	FS_RESERVED_FL     = 0x80000000 /* reserved for ext2 lib */
+)
+
+func ioctl(f *os.File, request uintptr, attrp *int32) error {
+	argp := uintptr(unsafe.Pointer(attrp))
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), request, argp)
+	if errno != 0 {
+		return os.NewSyscallError("ioctl", errno)
+	}
+
+	return nil
+}
+
+// GetAttr retrieves the attributes of a file on a linux filesystem
+func GetAttr(f *os.File) (int32, error) {
+	attr := int32(-1)
+	err := ioctl(f, _FS_IOC_GETFLAGS, &attr)
+	return attr, err
+}
+
+// SetAttr sets the attributes of a file on a linux filesystem to the given value
+func SetAttr(f *os.File, attr int32) error {
+	return ioctl(f, _FS_IOC_SETFLAGS, &attr)
+}

--- a/sbctl.go
+++ b/sbctl.go
@@ -200,7 +200,29 @@ func CreateKeys() {
 	}
 }
 
+var efivarFSFiles = []string{
+	"/sys/firmware/efi/efivars/PK-8be4df61-93ca-11d2-aa0d-00e098032b8c",
+	"/sys/firmware/efi/efivars/KEK-8be4df61-93ca-11d2-aa0d-00e098032b8c",
+	"/sys/firmware/efi/efivars/db-d719b2cb-3d3a-4596-a3bc-dad00e67656f",
+}
+
 func SyncKeys() {
+	errImmuable := false
+	for _, file := range efivarFSFiles {
+		b, err := IsImmutable(file)
+		if err != nil {
+			err1.Printf("Couldn't read file: %s\n", file)
+			os.Exit(1)
+		}
+		if !b {
+			err1.Printf("File is immutable: %s\n", file)
+			errImmuable = true
+		}
+	}
+	if errImmuable {
+		err1.Println("You need to chattr -i files in efivarfs")
+		os.Exit(1)
+	}
 	synced := SBKeySync(KeysPath)
 	if !synced {
 		err1.Println("Couldn't sync keys")

--- a/util.go
+++ b/util.go
@@ -66,3 +66,18 @@ func ReadOrCreateFile(filePath string) ([]byte, error) {
 
 	return f, nil
 }
+
+func IsImmutable(file string) (bool, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return false, err
+	}
+	attr, err := GetAttr(f)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if (attr & FS_IMMUTABLE_FL) != 0 {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
This allows us to give a sensible error for `enroll-keys` if the files
are set as immutable.

    $ sbctl enroll-keys
    ==> ERROR: File is immutable: /sys/firmware/efi/efivars/PK-8be4df61-93ca-11d2-aa0d-00e098032b8c
    ==> ERROR: File is immutable: /sys/firmware/efi/efivars/KEK-8be4df61-93ca-11d2-aa0d-00e098032b8c
    ==> ERROR: File is immutable: /sys/firmware/efi/efivars/db-d719b2cb-3d3a-4596-a3bc-dad00e67656f
    ==> ERROR: You need to chattr -i files in efivarfs

Signed-off-by: Morten Linderud <morten@linderud.pw>