### PR TITLE
sbctl: Check for persmission denied. Use errors package

### DIFF
--- a/sbctl.go
+++ b/sbctl.go
@@ -2,6 +2,7 @@ package sbctl
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"io/ioutil"
 	"log"
@@ -57,8 +58,10 @@ func VerifyESP() error {
 		checked[normalized] = true
 
 		// Check output file exists before checking if it's signed
-		if _, err := os.Stat(file.OutputFile); os.IsNotExist(err) {
-			warning2.Printf("%s does not exist\n", file.OutputFile)
+		if _, err := os.Open(file.OutputFile); errors.Is(err, os.ErrNotExist) {
+			err2.Printf("%s does not exist\n", file.OutputFile)
+		} else if errors.Is(err, os.ErrPermission) {
+			err2.Printf("%s permission denied. Can't read file\n", file.OutputFile)
 		} else if VerifyFile(DBCert, file.OutputFile) {
 			msg2.Printf("%s is signed\n", file.OutputFile)
 		} else {


### PR DESCRIPTION
We can always stat files, but it's enough to figure out if we can
actually check the signature. Instead we try to open the file.

This patch also moves us to the new errors package

    $ sbctl verify
    ==> Verifying file database and EFI images in /efi...
      -> WARNING: /boot/EFI/BOOT/BOOTX64.EFI is not signed
      -> WARNING: /boot/EFI/arch/fwupdx64.efi is not signed
      -> WARNING: /boot/EFI/systemd/systemd-bootx64.efi is not signed
      -> ERROR: /tmp/vmlinuz-linux does not exist
      -> ERROR: /tmp/vmlinuz-linuz-test permission denied. Can't read file

Fixes #46

Signed-off-by: Morten Linderud <morten@linderud.pw>