### PR TITLE
sbctl.hook: Renamed to be ordered last, added more paths

### DIFF
--- a/contrib/pacman/ZZ-sbctl.hook
+++ b/contrib/pacman/ZZ-sbctl.hook
@@ -6,6 +6,8 @@ Operation = Remove
 Target = boot/*
 Target = efi/*
 Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/initcpio/*
+Target = usr/lib/**/efi/*.efi*
 
 [Action]
 Description = Signing EFI binaries...


### PR DESCRIPTION
This should cover systemd and fwupd alike

Fixes #51

Signed-off-by: Morten Linderud <morten@linderud.pw>