### PR TITLE
Use arrays of arguments instead of spliting by white space 

### DIFF
--- a/bundles.go
+++ b/bundles.go
@@ -98,6 +98,7 @@ func GenerateBundle(bundle *Bundle) bool {
 	args = append(args, bundle.EFIStub, bundle.Output)
 	cmd := exec.Command("objcopy", args...)
 	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			return exitError.ExitCode() == 0

--- a/bundles.go
+++ b/bundles.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 )
 
 type Bundle struct {
@@ -85,16 +84,19 @@ func NewBundle() *Bundle {
 }
 
 func GenerateBundle(bundle *Bundle) bool {
-	args := ""
-	args += fmt.Sprintf("--add-section .osrel=%s --change-section-vma .osrel=0x20000 ", bundle.OSRelease)
-	args += fmt.Sprintf("--add-section .cmdline=%s --change-section-vma .cmdline=0x30000 ", bundle.Cmdline)
-	if bundle.Splash != "" {
-		args += fmt.Sprintf("--add-section .splash=%s --change-section-vma .splash=0x40000 ", bundle.Splash)
+	args := []string{
+		"--add-section", fmt.Sprintf(".osrel=%s", bundle.OSRelease), "--change-section-vma", ".osrel=0x20000",
+		"--add-section", fmt.Sprintf(".cmdline=%s", bundle.Cmdline), "--change-section-vma", ".cmdline=0x30000",
+		"--add-section", fmt.Sprintf(".linux=%s", bundle.KernelImage), "--change-section-vma", ".linux=0x2000000",
+		"--add-section", fmt.Sprintf(".initrd=%s", bundle.Initramfs), "--change-section-vma", ".initrd=0x3000000",
 	}
-	args += fmt.Sprintf("--add-section .linux=%s --change-section-vma .linux=0x2000000 ", bundle.KernelImage)
-	args += fmt.Sprintf("--add-section .initrd=%s --change-section-vma .initrd=0x3000000 ", bundle.Initramfs)
-	args += fmt.Sprintf("%s %s", bundle.EFIStub, bundle.Output)
-	cmd := exec.Command("objcopy", strings.Split(args, " ")...)
+
+	if bundle.Splash != "" {
+		args = append(args, "--add-section", fmt.Sprintf(".splash=%s", bundle.Splash), "--change-section-vma", ".splash=0x40000")
+	}
+
+	args = append(args, bundle.EFIStub, bundle.Output)
+	cmd := exec.Command("objcopy", args...)
 	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {

--- a/keys.go
+++ b/keys.go
@@ -99,8 +99,12 @@ func SaveKey(k []byte, path string) {
 
 func KeyToSiglist(UUID []byte, input string) []byte {
 	msg.Printf("Create EFI signature list %s.esl...", input)
-	args := fmt.Sprintf("--owner %s --type x509 --output %s.esl %s", UUID, input, input)
-	out, err := exec.Command("/usr/bin/sbsiglist", strings.Split(args, " ")...).Output()
+	out, err := exec.Command(
+		"sbsiglist",
+		"--owner", string(UUID),
+		"--type", "x509",
+		"--output", fmt.Sprintf("%s.esl", input), input,
+	).Output()
 	if err != nil {
 		log.Fatalf("Failed creating signature list: %s", err)
 	}
@@ -109,8 +113,7 @@ func KeyToSiglist(UUID []byte, input string) []byte {
 
 func SignEFIVariable(key, cert, varname, vardatafile, output string) []byte {
 	msg.Printf("Signing %s with %s...", vardatafile, key)
-	args := fmt.Sprintf("--key %s --cert %s --output %s %s %s", key, cert, output, varname, vardatafile)
-	out, err := exec.Command("/usr/bin/sbvarsign", strings.Split(args, " ")...).Output()
+	out, err := exec.Command("sbvarsign", "--key", key, "--cert", cert, "--output", output, varname, vardatafile).Output()
 	if err != nil {
 		log.Fatalf("Failed signing EFI variable: %s", err)
 	}
@@ -119,8 +122,7 @@ func SignEFIVariable(key, cert, varname, vardatafile, output string) []byte {
 
 func SBKeySync(dir string) bool {
 	msg.Printf("Syncing %s to EFI variables...", dir)
-	args := fmt.Sprintf("--pk --verbose --keystore %s", dir)
-	cmd := exec.Command("sbkeysync", strings.Split(args, " ")...)
+	cmd := exec.Command("sbkeysync", "--pk", "--verbose", "--keystore", dir)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
@@ -144,8 +146,7 @@ func SBKeySync(dir string) bool {
 }
 
 func VerifyFile(cert, file string) bool {
-	args := fmt.Sprintf("--cert %s %s", cert, file)
-	cmd := exec.Command("sbverify", strings.Split(args, " ")...)
+	cmd := exec.Command("sbverify", "--cert", cert, file)
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			return exitError.ExitCode() == 0
@@ -174,8 +175,7 @@ func SignFile(key, cert, file, output, checksum string) error {
 	}
 
 	msg2.Printf("Signing %s...", file)
-	args := fmt.Sprintf("--key %s --cert %s --output %s %s", key, cert, output, file)
-	_, err := exec.Command("sbsign", strings.Split(args, " ")...).Output()
+	_, err := exec.Command("sbsign", "--key", key, "--cert", cert, "--output", output, file).Output()
 	if err != nil {
 		return PrintGenerateError(err2, "Failed signing file: %s", err)
 	}


### PR DESCRIPTION
Second commit changes the place of `.splash` argument to be last instead of in the middle but I dont' believe that will change the result. I through the man page of `objcopy` and there is no mention of order at `--add-section` or `--change-section-vma`.

Closes #60 