### PR TITLE
Update man entry for default cmdline

### DIFF
--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -77,7 +77,7 @@ EFI binary commands
                         AMD microcode location.
 
                 *-c* 'PATH', *--cmdline* 'PATH';;
-                        Cmdline location. (default "/proc/cmdline")
+                        Cmdline location. (default "/etc/kernel/cmdline")
 
                 *-e* 'PATH', *--efi-stub* 'PATH';;
                         EFI Stub location. (default "/usr/lib/systemd/boot/efi/linuxx64.efi.stub")


### PR DESCRIPTION
The default cmdline is `/etc/kernel/cmdline`, but the man page said `/proc/cmdline`.