### PR TITLE
logging: use simple unicode symbols

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -8,8 +8,8 @@ import (
 )
 
 var (
-	OkSym    = "✔"
-	NotOkSym = "✘"
+	OkSym    = "✓"
+	NotOkSym = "✗"
 	WarnSym  = "‼"
 	UnkwnSym = "⁇"
 )


### PR DESCRIPTION
Use simple unicode symbols in logging, instead of (possibly) emojis.

These two symbols should exist in most monospace fonts, so they can be shown with correct colors, without falling back to emojis, in most cases. They are also what systemd uses in their yes/no style output.