### PR TITLE
Use /efi as a fallback if the ESP is not found

### DIFF
--- a/sbctl.go
+++ b/sbctl.go
@@ -83,7 +83,7 @@ func GetESP() string {
 		return entryToCheck.Mountpoint
 	}
 
-	return ""
+	return "efi"
 }
 
 func Sign(file, output string, enroll bool) error {


### PR DESCRIPTION
The current fallback is an empty string, which is never correct.

This will be correct in _some_ scenarios, but not perfect.

See #78