### PR TITLE
Add a new "backup" command

### DIFF
--- a/cmd/sbctl/backup.go
+++ b/cmd/sbctl/backup.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/foxboron/go-uefi/efi"
+	"github.com/foxboron/sbctl"
+	"github.com/foxboron/sbctl/logging"
+	"github.com/spf13/cobra"
+)
+
+var backupCmd = &cobra.Command{
+	Use:   "backup",
+	Short: "Back up currently booted entry.",
+	RunE:  RunBackup,
+}
+
+func CopyFile(sourcePath string, destPath string) error {
+	srcFile, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	err = destFile.Sync()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GenerateBackupFilename(original string) string {
+	extension := path.Ext(original)
+	name := strings.TrimSuffix(original, path.Ext(original))
+
+	return fmt.Sprintf("%s_backup%s", name, extension)
+}
+
+func RunBackup(cmd *cobra.Command, args []string) error {
+	if _, err := os.Stat("/sys/firmware/efi/efivars"); os.IsNotExist(err) {
+		return fmt.Errorf("system is not booted with UEFI")
+	}
+
+	name, err := efi.GetCurrentlyBootedEntry()
+	if err != nil {
+		return fmt.Errorf("error reading currently booted entry: %v", err)
+	}
+
+	current := fmt.Sprintf("%s/EFI/Linux/%s", sbctl.GetESP(), name)
+	backup := GenerateBackupFilename(current)
+
+	logging.Print("Backing up: %s -> %s.\n", current, backup)
+
+	err = CopyFile(current, backup)
+	if err != nil {
+		return fmt.Errorf("error creating backup file: %v", err)
+	}
+
+	if !cmdOptions.JsonOutput {
+		logging.Ok("Backup done.")
+	}
+	return nil
+}
+
+func init() {
+	CliCommands = append(CliCommands, cliCommand{
+		Cmd: backupCmd,
+	})
+}

--- a/contrib/aur/sbctl-git/PKGBUILD
+++ b/contrib/aur/sbctl-git/PKGBUILD
@@ -34,4 +34,5 @@ package(){
     ./sbctl completion zsh | install -Dm644 /dev/stdin "$pkgdir/usr/share/zsh/site-functions/_sbctl"
     ./sbctl completion fish | install -Dm644 /dev/stdin "$pkgdir/usr/share/fish/vendor_completions.d/sbctl.fish"
     install -Dm644 ./contrib/pacman/ZZ-sbctl.hook "${pkgdir}/usr/share/libalpm/hooks/99-sbctl.hook"
+    install -Dm644 ./contrib/systemd/sbctl-backup.service "${pkgdir}/usr/lib/systemd/system/sbctl-backup.service"
 }

--- a/contrib/systemd/sbctl-backup.service
+++ b/contrib/systemd/sbctl-backup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Backup currently booted EFI image
+
+[Service]
+ExecStart=/usr/bin/sbctl backup
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/anatol/vmtest v0.0.0-20210225191124-26540db15d49
 	github.com/fatih/color v1.12.0
-	github.com/foxboron/go-uefi v0.0.0-20210611230104-7a6a29e36155
+	github.com/foxboron/go-uefi v0.0.0-20210627112259-5c9af3e9edec
 	github.com/google/uuid v1.2.0
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/foxboron/go-uefi v0.0.0-20210602193603-8589bbab9380 h1:D8hRHRCC/jFjOg
 github.com/foxboron/go-uefi v0.0.0-20210602193603-8589bbab9380/go.mod h1:bLcrn48nYQOkijhTK2iQw1MjXbBqJTG0k8RP6ww+CGQ=
 github.com/foxboron/go-uefi v0.0.0-20210611230104-7a6a29e36155 h1:9RnTC3NVUwcFpHGGzDYd2LqED59D929P9rl+bq8JL2c=
 github.com/foxboron/go-uefi v0.0.0-20210611230104-7a6a29e36155/go.mod h1:bLcrn48nYQOkijhTK2iQw1MjXbBqJTG0k8RP6ww+CGQ=
+github.com/foxboron/go-uefi v0.0.0-20210627112259-5c9af3e9edec h1:QGNtWgySrEuovzPfHW0Oai5bEX/NaHLaL8kF2HDEuPc=
+github.com/foxboron/go-uefi v0.0.0-20210627112259-5c9af3e9edec/go.mod h1:bLcrn48nYQOkijhTK2iQw1MjXbBqJTG0k8RP6ww+CGQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -261,6 +263,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
This new command creates a backup of the currently booted EFI image.

This is ideal to run after a successful boot, and serves as a rescue mechanism: each time the system boots successfully, the entry used to boot is backed up, so if you break it before the next reboot, you have a backup/rescue one.

There's a bundled `systemd` service included to automate this.

---

If this looks good, I've two minor improvements to add here:

- If the source file changes _after_ the system booted, skip backing up.
- If we're currently booted of a backup entry, don't create a backup of the backup.