### PR TITLE
Ignore EOF errors in CheckMSDos

### DIFF
--- a/util.go
+++ b/util.go
@@ -105,6 +105,10 @@ func CheckMSDos(path string) (bool, error) {
 	// They contain "MZ" as the two first bytes
 	var header [2]byte
 	if _, err = io.ReadFull(r, header[:]); err != nil {
+		// File is smaller than 2 bytes
+		if errors.Is(err, io.EOF) {
+			return false, nil
+		}
 		return false, err
 	}
 	if !bytes.Equal(header[:], []byte{0x4d, 0x5a}) {


### PR DESCRIPTION
CheckMSDos attempts to read the first two bytes of a file to determine
if it is an MS-DOS executable. If a file (for whatever reason) is shorter,
attempting to read this will result in an `io.EOF` error.

The error can be safely ignore because such an error indicates that the file
could be read successfully, it just doesn't contain enough bytes.

Possibly resolves #96