### PR TITLE
Add convenient aliases for some sub-commands

### DIFF
--- a/cmd/sbctl/list-bundles.go
+++ b/cmd/sbctl/list-bundles.go
@@ -15,7 +15,10 @@ type JsonBundle struct {
 }
 
 var listBundlesCmd = &cobra.Command{
-	Use:   "list-bundles",
+	Use: "list-bundles",
+	Aliases: []string{
+		"ls-bundles",
+	},
 	Short: "List stored bundles",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		bundles := []JsonBundle{}

--- a/cmd/sbctl/list-files.go
+++ b/cmd/sbctl/list-files.go
@@ -9,7 +9,11 @@ import (
 )
 
 var listFilesCmd = &cobra.Command{
-	Use:   "list-files",
+	Use: "list-files",
+	Aliases: []string{
+		"ls-files",
+		"ls",
+	},
 	Short: "List enrolled files",
 	RunE:  RunList,
 }

--- a/cmd/sbctl/remove-bundle.go
+++ b/cmd/sbctl/remove-bundle.go
@@ -9,7 +9,10 @@ import (
 )
 
 var removeBundleCmd = &cobra.Command{
-	Use:   "remove-bundle",
+	Use: "remove-bundle",
+	Aliases: []string{
+		"rm-bundle",
+	},
 	Short: "Remove bundle from database",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {

--- a/cmd/sbctl/remove-file.go
+++ b/cmd/sbctl/remove-file.go
@@ -9,7 +9,11 @@ import (
 )
 
 var removeFileCmd = &cobra.Command{
-	Use:   "remove-file",
+	Use: "remove-file",
+	Aliases: []string{
+		"rm-file",
+		"rm",
+	},
 	Short: "Remove file from database",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {

--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -52,9 +52,13 @@ EFI signing commands
                 Generate all bundles before signing.
 
 **list-files**::
+**ls-files**::
+**ls**::
         Lists all enrolled EFI binaries.
 
 **remove-file** <FILE>::
+**rm-file** <FILE>::
+**rm** <FILE>::
         Removes the file from the signing database.
 
 **verify**::
@@ -113,9 +117,11 @@ EFI binary commands
                 Sign all the generated bundles.
 
 **remove-bundle** <NAME>::
+**rm-bundle** <NAME>::
         Removes a bundle from the list. This does not delete the bundle itself.
 
 **list-bundles**::
+**ls-bundle**::
         List all registered bundles to generate.
 
 


### PR DESCRIPTION
Add convenient aliases for some sub-commands.

Aliases added:

- `list-bundles`
  - `ls-bundles`
- `list-files`
  - `ls-files`
  - `ls`
- `remove-bundle`
  - `rm-bundle`
- `remove-file`
  - `rm-file`
  - `rm`

If you don't agree with the `ls` and `rm` aliases I can remove them.