### PR TITLE
Added 'Generate and sign GRUB EFI' to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,15 @@ Enrolled bundles:
 Generating EFI bundles....
 Wrote EFI bundle /efi/EFI/Linux/linux-linux.efi
 ```
+
+# Generate and sign GRUB EFI 
+```
+# sudo grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --modules="normal test efi_gop efi_uga search echo linux all_video gfxmenu gfxterm_background gfxterm_menu gfxterm loadenv configfile tpm" --disable-shim-lock
+
+Installing for x86_64-efi platform.
+Installation finished. No error reported.
+
+# sbctl sign -s /boot/efi/EFI/GRUB/grubx64.efi
+✓ Signed /boot/efi/EFI/GRUB/grubx64.efi
+// Reboot!
+```


### PR DESCRIPTION
Added this to readme.md, it'll save someone a lot of time, it fixes grub rescue error, 

# Generate and sign GRUB EFI
```
# sudo grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=GRUB --modules="normal test efi_gop efi_uga search echo linux all_video gfxmenu gfxterm_background gfxterm_menu gfxterm loadenv configfile tpm" --disable-shim-lock

Installing for x86_64-efi platform.
Installation finished. No error reported.

# sbctl sign -s /boot/efi/EFI/GRUB/grubx64.efi
✓ Signed /boot/efi/EFI/GRUB/grubx64.efi
// Reboot!
```
I was editing grub config to chainload EFI, though the solution was pretty simple.
https://github.com/Foxboron/sbctl/issues/91 - I looked up at this issue before I started messing with grub config, as a noobie I couldn't do it properly, I did grub-install and sign grubx64.efi but in /EFI/Manjaro/grubx64.efi which obviously didn't fix the issue. 
I also made lots of rookie mistakes that I'll address with fixes, Hope this helps out some noobie like me!