### PR TITLE
Fix minor typo

### DIFF
--- a/cmd/sbctl/sign-all.go
+++ b/cmd/sbctl/sign-all.go
@@ -32,7 +32,7 @@ var signAllCmd = &cobra.Command{
 
 			err := sbctl.SignFile(sbctl.DBKey, sbctl.DBCert, entry.File, entry.OutputFile, entry.Checksum)
 			if errors.Is(err, sbctl.ErrAlreadySigned) {
-				logging.Print("File have already been signed %s\n", entry.OutputFile)
+				logging.Print("File has already been signed %s\n", entry.OutputFile)
 			} else if err != nil {
 				return fmt.Errorf("failed signing %s: %w", entry.File, err)
 			} else {

--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -280,7 +280,7 @@ When we do system updated we can run 'sign-all' to resign all the saved files
 from earlier.
 
         $ sbctl sign-all
-        File have already been signed /boot/vmlinuz-linux
+        File has already been signed /boot/vmlinuz-linux
         ✓ Signed /efi/EFI/BOOT/BOOTX64.EFI
 
 sbctl supports creating unified kernel images. These UEFI executables bundles


### PR DESCRIPTION
#113 fixed this same thing for `sign.go`, hopefully this is the last one :)