### PR TITLE
WIP: Add support for loading certificates from dbDefault

### DIFF
--- a/certs/builtin.go
+++ b/certs/builtin.go
@@ -1,0 +1,71 @@
+package certs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/foxboron/go-uefi/efi/attributes"
+	"github.com/foxboron/go-uefi/efi/signature"
+	"github.com/foxboron/go-uefi/efi/util"
+)
+
+var (
+	efiGlobalGuid                = util.EFIGUID{0x8be4df61, 0x93ca, 0x11d2, [8]uint8{0xaa, 0x0d, 0x00, 0xe0, 0x98, 0x03, 0x2b, 0x8c}}
+	defaultSignatureDatabaseName = "dbDefault"
+)
+
+type builtinSignatureDataEntry struct {
+	SignatureType util.EFIGUID
+	Data          *signature.SignatureData
+}
+
+func GetBuiltinCertificates() (*signature.SignatureDatabase, error) {
+	attr, buf, err := attributes.ReadEfivarsWithGuid(defaultSignatureDatabaseName, efiGlobalGuid)
+	if err != nil {
+		if err == os.ErrNotExist {
+			// not finding a default db is not a failure!
+			return signature.NewSignatureDatabase(), nil
+		}
+		return nil, err
+	}
+
+	if attr&attributes.EFI_VARIABLE_NON_VOLATILE != 0 {
+		// If this variable has non-volatile storage, a malicious user could have created it.
+		// The EDK2 implementation of default Secure Boot stores marks them volatile.
+		return nil, fmt.Errorf("Vendor default database is non-volatile (and is vulnerable to being tampered with)")
+	}
+
+	database, err := signature.ReadSignatureDatabase(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	detect := map[util.EFIGUID]string{}
+	for k, v := range oemGUID {
+		detect[v] = k
+	}
+
+	removals := make([]*builtinSignatureDataEntry, 0, 8)
+
+	// Remove vendor certificates that are already covered by the built-in vendor database.
+	for _, l := range database {
+		if l.SignatureType == signature.CERT_X509_GUID || l.SignatureType == signature.CERT_X509_SHA256_GUID {
+			for _, s := range l.Signatures {
+				if _, ok := detect[s.Owner]; ok {
+					removals = append(removals, &builtinSignatureDataEntry{
+						SignatureType: l.SignatureType,
+						Data:          &s,
+					})
+				}
+			}
+		}
+	}
+
+	// Depending on the implementation of .RemoveSignature, this could be
+	// expensive; however, we don't expect dbDebault to be particularly huge.
+	for _, s := range removals {
+		database.RemoveSignature(s.SignatureType, s.Data)
+	}
+
+	return &database, nil
+}


### PR DESCRIPTION
⚠️ I'm submitting this as a work-in-progress right now. Things I'd like to do before I mark it ready for review:

- [ ] Display a list of firmware-backed vendor certificates in `sbctl status`
- [ ] find the right place for `GetBuiltinCertificates`; Package `certs` isn't necessarily the right place
- [ ] more?

---

This pull request teaches `sbctl enroll-keys` to include keys indicated
by the firmware as being part of the default Secure Boot configuration.

Entries are read from dbDefault, and ones that have the same Owner GUID
as another entry in the vendor set (such as `microsoft`) are skipped.
This should give the user better control over whose certificates are
enrolled.

I've tested this by stubbing out writing and saving the sig-list to a file:

```
# ./sbctl enroll-keys -i -f -m             
Enrolling keys to EFI variables...
With vendor keys from microsoft...
With vendor certificates built into the firmware...✓ 
Enrolled keys to the EFI variables!

# sig-list-to-certs TEST.db.unsigned db  
X509 Header sls=1320, header=0, sig=1276
file db-0.der: Guid 8e2b961d-6ca9-47fe-b1cb-d92f278d85f3
Written 1276 bytes
X509 Header sls=1600, header=0, sig=1556
file db-1.der: Guid 77fa9abd-0359-4d32-bd60-28f4e78f784b
Written 1556 bytes
X509 Header sls=1543, header=0, sig=1499
file db-2.der: Guid 77fa9abd-0359-4d32-bd60-28f4e78f784b
Written 1499 bytes
X509 Header sls=739, header=0, sig=695
file db-3.der: Guid 55555555-5555-5555-5555-555555555555
Written 695 bytes
```

In my case, the machine's OEM certificates are owned by GUID
55555555-5555-5555-5555-555555555555.