### PR TITLE
Fix crash when ESP is not mounted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 tags
 releases/*
-sbctl
-!sbctl/
+/sbctl
 docs/*.8
 rootfs*
 bzImage

--- a/bundles.go
+++ b/bundles.go
@@ -96,7 +96,8 @@ func GetEfistub() (string, error) {
 func NewBundle() (bundle *Bundle, err error) {
 	esp, err := GetESP()
 	if err != nil {
-		return
+		// This is not critical, just use an empty default.
+		esp = ""
 	}
 
 	stub, err := GetEfistub()


### PR DESCRIPTION
Generating a new bundle with an unmounted ESP would crash trying to find
one, even if one was explicitly specified.

This was due to Bundle instances always being created with a discovered
ESP path. However, this path is always overwritten based on the value
provided by the user, meaning that this default is unused and always
overwritten.

This changes NewBundle to simply use an empty ESP if finding one fails.
This has no impact on `sbctl` itself. This change COULD impact
applications using this codes as a library, but this only affects code
that previously panicked.

Fixes: https://github.com/Foxboron/sbctl/issues/132
