### PR TITLE
Drop checksum field from signed files db

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       container: voidlinux/voidlinux-musl
       steps:
          # update xbps, if necessary
-         - run: xbps-install -Syu || ( xbps-install -yu xbps && xbps-install -yu )
+         - run: xbps-install -Syu || ( xbps-install -yu xbps && xbps-install -Syu)
          - run: xbps-install -y make go asciidoc gcc git
          - uses: actions/checkout@v1
          - run: git config --global --add safe.directory $(pwd)

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 tags
 releases/*
-sbctl
-!sbctl/
+/sbctl
 docs/*.8
 rootfs*
 bzImage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ needs to be signed in the boot chain.
 It is written top-to-bottom in [Golang](https://golang.org/) using
 [go-uefi](https://github.com/Foxboron/go-uefi) for the API layer and doesn't
 rely on existing secure boot tooling. It also tries to sport some integration
-testing towards towards [tianocore](https://www.tianocore.org/) utilizing
+testing towards [tianocore](https://www.tianocore.org/) utilizing
 [vmtest](https://github.com/anatol/vmtest).
 
 ![](https://pkgbuild.com/~foxboron/sbctl_demo.gif)

--- a/bundles.go
+++ b/bundles.go
@@ -33,7 +33,9 @@ func ReadBundleDatabase(dbpath string) (Bundles, error) {
 		return nil, err
 	}
 	bundles := make(Bundles)
-	json.Unmarshal(f, &bundles)
+	if err = json.Unmarshal(f, &bundles); err != nil {
+		return nil, fmt.Errorf("failed to parse json: %v", err)
+	}
 	return bundles, nil
 }
 

--- a/bundles.go
+++ b/bundles.go
@@ -33,6 +33,9 @@ func ReadBundleDatabase(dbpath string) (Bundles, error) {
 		return nil, err
 	}
 	bundles := make(Bundles)
+	if len(f) == 0 {
+		return bundles, nil
+	}
 	if err = json.Unmarshal(f, &bundles); err != nil {
 		return nil, fmt.Errorf("failed to parse json: %v", err)
 	}

--- a/bundles.go
+++ b/bundles.go
@@ -96,7 +96,8 @@ func GetEfistub() (string, error) {
 func NewBundle() (bundle *Bundle, err error) {
 	esp, err := GetESP()
 	if err != nil {
-		return
+		// This is not critical, just use an empty default.
+		esp = ""
 	}
 
 	stub, err := GetEfistub()

--- a/certs/certs.go
+++ b/certs/certs.go
@@ -42,7 +42,9 @@ func GetCerts(oem string) (*signature.SignatureDatabase, error) {
 			continue
 		}
 		buf, _ := content.ReadFile(path)
-		sigdb.Append(signature.CERT_X509_GUID, GUID, buf)
+		if err := sigdb.Append(signature.CERT_X509_GUID, GUID, buf); err != nil {
+			return nil, err
+		}
 	}
 	return sigdb, nil
 }

--- a/cmd/sbctl/completions.go
+++ b/cmd/sbctl/completions.go
@@ -12,8 +12,8 @@ func completionBashCmd() *cobra.Command {
 	var completionCmd = &cobra.Command{
 		Use:    "bash",
 		Hidden: true,
-		Run: func(cmd *cobra.Command, args []string) {
-			rootCmd.GenBashCompletion(os.Stdout)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rootCmd.GenBashCompletion(os.Stdout)
 		},
 	}
 	return completionCmd
@@ -23,8 +23,8 @@ func completionZshCmd() *cobra.Command {
 	var completionCmd = &cobra.Command{
 		Use:    "zsh",
 		Hidden: true,
-		Run: func(cmd *cobra.Command, args []string) {
-			rootCmd.GenZshCompletion(os.Stdout)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rootCmd.GenZshCompletion(os.Stdout)
 		},
 	}
 	return completionCmd
@@ -34,8 +34,8 @@ func completionFishCmd() *cobra.Command {
 	var completionCmd = &cobra.Command{
 		Use:    "fish",
 		Hidden: true,
-		Run: func(cmd *cobra.Command, args []string) {
-			rootCmd.GenFishCompletion(os.Stdout, true)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rootCmd.GenFishCompletion(os.Stdout, true)
 		},
 	}
 	return completionCmd

--- a/cmd/sbctl/enroll-keys.go
+++ b/cmd/sbctl/enroll-keys.go
@@ -60,7 +60,9 @@ func KeySync(guid util.EFIGUID, keydir string, oems []string) error {
 	}
 
 	sigdb = signature.NewSignatureDatabase()
-	sigdb.Append(signature.CERT_X509_GUID, guid, dbPem)
+	if err = sigdb.Append(signature.CERT_X509_GUID, guid, dbPem); err != nil {
+		return err
+	}
 
 	if len(oems) > 0 {
 		for _, oem := range oems {
@@ -90,13 +92,17 @@ func KeySync(guid util.EFIGUID, keydir string, oems []string) error {
 	}
 
 	sigdb = signature.NewSignatureDatabase()
-	sigdb.Append(signature.CERT_X509_GUID, guid, KEKPem)
+	if err = sigdb.Append(signature.CERT_X509_GUID, guid, KEKPem); err != nil {
+		return err
+	}
 	if err := sbctl.Enroll(sigdb, KEKPem, PKKey, PKPem, "KEK"); err != nil {
 		return err
 	}
 
 	sigdb = signature.NewSignatureDatabase()
-	sigdb.Append(signature.CERT_X509_GUID, guid, PKPem)
+	if err = sigdb.Append(signature.CERT_X509_GUID, guid, PKPem); err != nil {
+		return nil
+	}
 	if err := sbctl.Enroll(sigdb, PKPem, PKKey, PKPem, "PK"); err != nil {
 		return err
 	}
@@ -116,7 +122,7 @@ func RunEnrollKeys(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
-	if (!enrollKeysCmdOptions.Force && !enrollKeysCmdOptions.TPMEventlogChecksums && !enrollKeysCmdOptions.MicrosoftKeys) {
+	if !enrollKeysCmdOptions.Force && !enrollKeysCmdOptions.TPMEventlogChecksums && !enrollKeysCmdOptions.MicrosoftKeys {
 		if err := sbctl.CheckEventlogOprom(systemEventlog); err != nil {
 			return err
 		}

--- a/cmd/sbctl/list-bundles.go
+++ b/cmd/sbctl/list-bundles.go
@@ -69,7 +69,7 @@ var listBundlesCmd = &cobra.Command{
 			return err
 		}
 		if cmdOptions.JsonOutput {
-			JsonOut(bundles)
+			return JsonOut(bundles)
 		}
 		return nil
 	},

--- a/cmd/sbctl/list-files.go
+++ b/cmd/sbctl/list-files.go
@@ -55,7 +55,7 @@ func RunList(_ *cobra.Command, args []string) error {
 		return err
 	}
 	if cmdOptions.JsonOutput {
-		JsonOut(files)
+		return JsonOut(files)
 	}
 	return nil
 }

--- a/cmd/sbctl/status.go
+++ b/cmd/sbctl/status.go
@@ -88,7 +88,9 @@ func RunStatus(cmd *cobra.Command, args []string) error {
 		stat.Vendors = keys
 	}
 	if cmdOptions.JsonOutput {
-		JsonOut(stat)
+		if err := JsonOut(stat); err != nil {
+			return err
+		}
 	} else {
 		PrintStatus(stat)
 	}

--- a/database.go
+++ b/database.go
@@ -20,7 +20,9 @@ func ReadFileDatabase(dbpath string) (SigningEntries, error) {
 	}
 
 	files := make(SigningEntries)
-	json.Unmarshal(f, &files)
+	if err = json.Unmarshal(f, &files); err != nil {
+		return nil, fmt.Errorf("failed to parse json: %v", err)
+	}
 
 	return files, nil
 }

--- a/database.go
+++ b/database.go
@@ -9,7 +9,6 @@ import (
 type SigningEntry struct {
 	File       string `json:"file"`
 	OutputFile string `json:"output_file"`
-	Checksum   string `json:"checksum"`
 }
 
 type SigningEntries map[string]*SigningEntry

--- a/database.go
+++ b/database.go
@@ -20,6 +20,9 @@ func ReadFileDatabase(dbpath string) (SigningEntries, error) {
 	}
 
 	files := make(SigningEntries)
+	if len(f) == 0 {
+		return files, nil
+	}
 	if err = json.Unmarshal(f, &files); err != nil {
 		return nil, fmt.Errorf("failed to parse json: %v", err)
 	}

--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -147,13 +147,13 @@ EFI binary commands
                         Help for bundle.
 
                 *-f* 'PATH', *--initramfs* 'PATH';;
-                        Initramfs location. (default "/efi/initramfs-linux.img")
+                        Initramfs location. (default "/boot/initramfs-linux.img")
 
                 *-i* 'PATH', *--intelucode* 'PATH';;
                         Intel microcode location.
 
                 *-k* 'PATH', *--kernel-img* 'PATH';;
-                        Kernel image location. (default "/efi/vmlinuz-linux")
+                        Kernel image location. (default "/boot/vmlinuz-linux")
 
                 *-o* 'PATH', *--os-release* 'PATH';;
                         OS Release file location. (default "/usr/lib/os-release")

--- a/keys.go
+++ b/keys.go
@@ -87,9 +87,10 @@ func CreateKey(name string) ([]byte, []byte, error) {
 }
 
 func SaveKey(k []byte, file string) error {
-	os.MkdirAll(filepath.Dir(file), os.ModePerm)
-	err := os.WriteFile(file, k, 0400)
-	if err != nil {
+	if err := os.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
+		return err
+	}
+	if err := os.WriteFile(file, k, 0400); err != nil {
 		return err
 	}
 	return nil
@@ -274,8 +275,14 @@ func InitializeSecureBootKeys(output string) error {
 			return err
 		}
 		path := filepath.Join(output, key.Key)
-		SaveKey(keyfile, filepath.Join(path, fmt.Sprintf("%s.key", key.Key)))
-		SaveKey(cert, filepath.Join(path, fmt.Sprintf("%s.pem", key.Key)))
+
+		if err = SaveKey(keyfile, filepath.Join(path, fmt.Sprintf("%s.key", key.Key))); err != nil {
+			return err
+		}
+
+		if err = SaveKey(cert, filepath.Join(path, fmt.Sprintf("%s.pem", key.Key))); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,0 +1,57 @@
+package sbctl
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewFile(t *testing.T) {
+	dbPath := t.TempDir() // Why does THIS take so long!?
+
+	if err := InitializeSecureBootKeys(dbPath); err != nil {
+		t.Fatalf("Error creating test keys: %v", err)
+	}
+
+	dbKey := filepath.Join(dbPath, "db", "db.key")
+	dbCert := filepath.Join(dbPath, "db", "db.pem")
+
+	// Possible leftover from previous test runs.
+	_ = os.Remove("./test-output.bin")
+	_ = os.Remove("./test-output.bin2")
+
+	err := SignFile(dbKey, dbCert, "/usr/lib/systemd/boot/efi/systemd-bootaa64.efi", "./test-output.bin")
+	if err != nil {
+		t.Fatalf("Failed to sign unsigned file: %v", err)
+	}
+
+	err = SignFile(dbKey, dbCert, "/usr/lib/systemd/boot/efi/systemd-bootaa64.efi", "./test-output.bin")
+	if err != ErrAlreadySigned {
+		t.Fatalf("Signing already signed file did not return ErrAlreadySigned, retured: %v", err)
+	}
+
+	err = SignFile(dbKey, dbCert, "./test-output.bin", "./test-output2.bin")
+	if err != nil {
+		t.Fatalf("Error signing already-signed file to new output location: %v", err)
+	}
+
+	checksum1, err := ChecksumFile("./test-output.bin")
+	if err != nil {
+		t.Fatalf("Error calling stat() for file I just created: %v", err)
+	}
+
+	checksum2, err := ChecksumFile("./test-output2.bin")
+	if err != nil {
+		t.Fatalf("Error calling stat() for file I just created: %v", err)
+	}
+
+	if checksum1 != checksum2 {
+		// This would happen if the file is signed again, which is wrong.
+		t.Errorf("Signing already-signed file to new location yielded different results.")
+	}
+
+	err = SignFile(dbKey, dbCert, "./test-output.bin", "./test-output2.bin")
+	if err != ErrAlreadySigned {
+		t.Fatalf("Signing already signed file did not return ErrAlreadySigned, retured: %v", err)
+	}
+}

--- a/sbctl.go
+++ b/sbctl.go
@@ -41,7 +41,7 @@ func GetESP() (string, error) {
 	}
 
 	for _, location := range espLocations {
-		// "Touch" a file inside all candiadate locations to trigger an
+		// "Read" a file inside all candiadate locations to trigger an
 		// automount if there's an automount partition.
 		os.Stat(fmt.Sprintf("%s/does-not-exist", location))
 	}

--- a/sbctl.go
+++ b/sbctl.go
@@ -55,7 +55,9 @@ func GetESP() (string, error) {
 	}
 
 	var lsblkRoot LsblkRoot
-	json.Unmarshal(out, &lsblkRoot)
+	if err = json.Unmarshal(out, &lsblkRoot); err != nil {
+		return "", fmt.Errorf("failed to parse json: %v", err)
+	}
 
 	var pathBootEntry *LsblkEntry
 	var pathBootEfiEntry *LsblkEntry

--- a/sbctl.go
+++ b/sbctl.go
@@ -113,8 +113,6 @@ func Sign(file, output string, enroll bool) error {
 		}
 	}
 
-	err = nil
-
 	files, err := ReadFileDatabase(DBPath)
 	if err != nil {
 		return fmt.Errorf("couldn't open database: %s", DBPath)

--- a/sbctl.go
+++ b/sbctl.go
@@ -120,22 +120,17 @@ func Sign(file, output string, enroll bool) error {
 		return fmt.Errorf("couldn't open database: %s", DBPath)
 	}
 	if entry, ok := files[file]; ok {
-		err = SignFile(DBKey, DBCert, entry.File, entry.OutputFile, entry.Checksum)
+		err = SignFile(DBKey, DBCert, entry.File, entry.OutputFile)
 		// return early if signing fails
 		if err != nil {
 			return err
 		}
-		checksum, err := ChecksumFile(file)
-		if err != nil {
-			return err
-		}
-		entry.Checksum = checksum
 		files[file] = entry
 		if err := WriteFileDatabase(DBPath, files); err != nil {
 			return err
 		}
 	} else {
-		err = SignFile(DBKey, DBCert, file, output, "")
+		err = SignFile(DBKey, DBCert, file, output)
 		// return early if signing fails
 		if err != nil {
 			return err
@@ -143,11 +138,7 @@ func Sign(file, output string, enroll bool) error {
 	}
 
 	if enroll {
-		checksum, err := ChecksumFile(file)
-		if err != nil {
-			return err
-		}
-		files[file] = &SigningEntry{File: file, OutputFile: output, Checksum: checksum}
+		files[file] = &SigningEntry{File: file, OutputFile: output}
 		if err := WriteFileDatabase(DBPath, files); err != nil {
 			return err
 		}

--- a/sbctl.go
+++ b/sbctl.go
@@ -43,7 +43,7 @@ func GetESP() (string, error) {
 	for _, location := range espLocations {
 		// "Read" a file inside all candiadate locations to trigger an
 		// automount if there's an automount partition.
-		os.Stat(fmt.Sprintf("%s/does-not-exist", location))
+		_, _ = os.Stat(fmt.Sprintf("%s/does-not-exist", location))
 	}
 
 	out, err := exec.Command(

--- a/tpm.go
+++ b/tpm.go
@@ -60,7 +60,9 @@ func GetEventlogChecksums(eventlog string) (*signature.SignatureDatabase, error)
 	for _, event := range events {
 		switch event.Type.String() {
 		case "EV_EFI_BOOT_SERVICES_DRIVER":
-			sigdb.Append(signature.CERT_SHA256_GUID, eventlogGUID, event.Digest)
+			if err = sigdb.Append(signature.CERT_SHA256_GUID, eventlogGUID, event.Digest); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return sigdb, nil

--- a/util.go
+++ b/util.go
@@ -172,7 +172,9 @@ func CopyFile(src, dst string) error {
 		return err
 	}
 	defer f.Close()
-	io.Copy(f, source)
+	if _, err = io.Copy(f, source); err != nil {
+		return err
+	}
 	si, err := os.Stat(src)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is required before moving files from `/usr` into their proper
locations.

See: https://github.com/Foxboron/sbctl/issues/57