### PR TITLE
Fix POSIX sh comparison

### DIFF
--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -7,7 +7,7 @@ KERNEL_IMAGE="$4"
 
 IMAGE_FILE="$ENTRY_DIR_ABS/linux"
 
-if [ "$KERNEL_INSTALL_LAYOUT" == "uki" ]; then
+if [ "$KERNEL_INSTALL_LAYOUT" = "uki" ]; then
 	UKI_DIR="$KERNEL_INSTALL_BOOT_ROOT/EFI/Linux"
 	TRIES_FILE="${KERNEL_INSTALL_CONF_ROOT:-/etc/kernel}/tries"
 


### PR DESCRIPTION
In POSIX sh == doesn't really exist; shellcheck warns about this.