### PR TITLE
91-sbctl.install: don't sign without signing keys

### DIFF
--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -28,6 +28,14 @@ fi
 case "$COMMAND" in
 add)
 	printf 'sbctl: Signing kernel %s\n' "$IMAGE_FILE"
+
+	# exit without error if keys don't exist
+	# https://github.com/Foxboron/sbctl/issues/187
+	if ! test -d /usr/share/secureboot/keys; then
+		echo "Secureboot key directory doesn't exist, not signing!"
+		exit 0
+	fi
+
 	sbctl sign -s "$IMAGE_FILE" 1>/dev/null
 	;;
 remove)


### PR DESCRIPTION
It's expected that signing doesn't work without having previously generated keys, so don't try to sign when keys don't exist.

Closes: https://github.com/Foxboron/sbctl/issues/187
Signed-off-by: John Helmert III <ajak@gentoo.org>