### PR TITLE
pacman: Add 'extramodules' target to hook

### DIFF
--- a/contrib/pacman/ZZ-sbctl.hook
+++ b/contrib/pacman/ZZ-sbctl.hook
@@ -6,6 +6,7 @@ Operation = Remove
 Target = boot/*
 Target = efi/*
 Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/modules/*/extramodules/*
 Target = usr/lib/initcpio/*
 Target = usr/lib/**/efi/*.efi*
 


### PR DESCRIPTION
archlinux install out-of-tree dirvers such as nvidia under `usr/lib/modules/*/extramodules/*`. Modifying out-of-tree dirvers could trigger mkinitcpio.
