### PR TITLE
Always include vendor keys in status output

### DIFF
--- a/cmd/sbctl/status.go
+++ b/cmd/sbctl/status.go
@@ -65,7 +65,7 @@ func PrintStatus(s *Status) {
 	if len(s.Vendors) > 0 {
 		logging.Println(strings.Join(s.Vendors, " "))
 	} else {
-		logging.Println("n/a")
+		logging.Println("none")
 	}
 }
 

--- a/cmd/sbctl/status.go
+++ b/cmd/sbctl/status.go
@@ -61,9 +61,11 @@ func PrintStatus(s *Status) {
 	}
 	// TODO: We only have microsoft keys
 	// this needs to be extended for more keys in the future
+	logging.Print("Vendor Keys:\t")
 	if len(s.Vendors) > 0 {
-		logging.Print("Vendor Keys:\t")
 		logging.Println(strings.Join(s.Vendors, " "))
+	} else {
+		logging.Println("n/a")
 	}
 }
 


### PR DESCRIPTION
Do not hide the "vendor keys" line if there are no vendor keys; instead indicate explicitly that no vendor keys are present.

I found this behaviour a bit confusing when setting up secure boot; it took me a while to realize that the MS keys were indeed not installed, because a flag in the firmware UI suggested otherwise, and I assumed sbctl was misbehaving.

Given that the absence of vendor keys can cause a lot of trouble depending on the hardware, I also think it's better to indicate their absence explicitly.