### PR TITLE
enroll-keys: implement --export

### DIFF
--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -90,7 +90,7 @@ func rotateDb(oldKeys *Keys, newKeys *Keys) error {
 		return err
 	}
 	sl.Append(signature.CERT_X509_GUID, *guid, newKeys.DbCert)
-	return sbctl.Enroll(sl, newKeys.DbCert, newKeys.KEKKey, newKeys.KEKCert, "db")
+	return sbctl.Enroll(sl, newKeys.KEKKey, newKeys.KEKCert, "db")
 }
 
 func rotateKEK(oldKeys *Keys, newKeys *Keys) error {
@@ -111,7 +111,7 @@ func rotateKEK(oldKeys *Keys, newKeys *Keys) error {
 		return err
 	}
 	sl.Append(signature.CERT_X509_GUID, *guid, newKeys.KEKCert)
-	return sbctl.Enroll(sl, newKeys.KEKCert, newKeys.PKKey, newKeys.PKCert, "KEK")
+	return sbctl.Enroll(sl, newKeys.PKKey, newKeys.PKCert, "KEK")
 }
 
 func rotatePK(oldKeys *Keys, newKeys *Keys) error {
@@ -131,7 +131,7 @@ func rotatePK(oldKeys *Keys, newKeys *Keys) error {
 	// We have most likely reset the PK so we don't care about missing sigdata
 	sl.Remove(signature.CERT_X509_GUID, *guid, pkCert.Raw)
 	sl.Append(signature.CERT_X509_GUID, *guid, newKeys.PKCert)
-	return sbctl.Enroll(sl, newKeys.PKCert, oldKeys.PKKey, oldKeys.PKCert, "PK")
+	return sbctl.Enroll(sl, oldKeys.PKKey, oldKeys.PKCert, "PK")
 }
 
 func RunRotateKeys(cmd *cobra.Command, args []string) error {

--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -67,6 +67,13 @@ EFI signing commands
                 files and unset the immutable attribute before enrolling
                 certificates.
 
+        *--export*;;
+                Export the keys we intend to enroll as EFI Signature Lists
+                (esl), or EFI Authenticated Variables (auth) into the current
+                working directory.
+
+                Valid values are: esl, auth.
+
 **sign** <FILE>...::
         Signs an EFI binary with the created key. The file will be checked for
         valid signatures to avoid duplicates.

--- a/go.mod
+++ b/go.mod
@@ -23,5 +23,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/text v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -823,6 +823,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/keys.go
+++ b/keys.go
@@ -97,16 +97,20 @@ func SaveKey(k []byte, file string) error {
 	return nil
 }
 
-func Enroll(sigdb *signature.SignatureDatabase, cert, signerKey, signerPem []byte, efivar string) error {
+func SignDatabase(sigdb *signature.SignatureDatabase, signerKey, signerPem []byte, efivar string) ([]byte, error) {
 	key, err := util.ReadKey(signerKey)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	crt, err := util.ReadCert(signerPem)
 	if err != nil {
-		return nil
+		return nil, err
 	}
-	signedBuf, err := efi.SignEFIVariable(key, crt, efivar, sigdb.Bytes())
+	return efi.SignEFIVariable(key, crt, efivar, sigdb.Bytes())
+}
+
+func Enroll(sigdb *signature.SignatureDatabase, signerKey, signerPem []byte, efivar string) error {
+	signedBuf, err := SignDatabase(sigdb, signerKey, signerPem, efivar)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Export the keys we intend to enroll as .auth or .esl files