### PR TITLE
Add support for OEM dbx enrollment

### DIFF
--- a/cmd/sbctl/enroll-keys.go
+++ b/cmd/sbctl/enroll-keys.go
@@ -137,6 +137,13 @@ func KeySync(guid util.EFIGUID, keydir string, oems []string) error {
 			}
 			sigdb.AppendDatabase(oemSigDb)
 
+			// dbx
+			oemSigDbx, err := certs.GetOEMCerts(oem, "dbx")
+			if err != nil {
+				return fmt.Errorf("could not enroll db keys: %w", err)
+			}
+			sigdbx.AppendDatabase(oemSigDbx)
+
 			// KEK
 			oemSigKEK, err := certs.GetOEMCerts(oem, "KEK")
 			if err != nil {
@@ -155,6 +162,13 @@ func KeySync(guid util.EFIGUID, keydir string, oems []string) error {
 			}
 			sigdb.AppendDatabase(customSigDb)
 
+			// dbx
+			customSigDbx, err := certs.GetCustomCerts(keydir, "dbx")
+			if err != nil {
+				return fmt.Errorf("could not enroll custom dbx keys: %w", err)
+			}
+			sigdbx.AppendDatabase(customSigDbx)
+
 			// KEK
 			customSigKEK, err := certs.GetCustomCerts(keydir, "KEK")
 			if err != nil {
@@ -172,6 +186,8 @@ func KeySync(guid util.EFIGUID, keydir string, oems []string) error {
 				switch cert {
 				case "db":
 					sigdb.AppendDatabase(builtinSigDb)
+				case "dbx":
+					sigdbx.AppendDatabase(builtinSigDb)
 				case "KEK":
 					sigkek.AppendDatabase(builtinSigDb)
 				case "PK":


### PR DESCRIPTION
Followup to #236. This adds support for custom `dbx` databases.
I also added the microsoft one for completenes, but didn't add the current dbx, since that's maybe not the best idea and this should be fetched at runtime rather than be compiled in.

I tested the enrollment of `dbx` with the `--custom` argument on a qemu virtual machine.