### PR TITLE
Add Debian repository information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ For Alpine Linux:
 $ apk add sbctl
 ```
 
+For Debian Linux:
+
+Add [Julian's repository](https://gitlab.com/julianfairfax/package-repo#how-to-add-repository-for-debian-based-linux-distributions), then run:
+```
+$ sudo apt update # after adding the repository
+$ sudo apt install sbctl
+```
+
 You can find a updated list of [sbctl packages on
 Repology](https://repology.org/project/sbctl/versions).
 


### PR DESCRIPTION
I have created a Debian package for sbctl which is available in my Debian repository.

In the future, I may look into getting this tool into the official Debian repos, but that is not as easy as creating this package was.

I also spent a lot of time trying to create something similar to the pacman hook, for automatic resigning after a modification of Debian's EFI files, but I was unsuccessful.

I don't have time to further investigate that, but, if someone knows how to do this, within the framework of the [package setup](https://gitlab.com/julianfairfax/package-repo/-/blob/main/sbctl/build_deb.sh?ref_type=heads), then I will implement it.

In any case, hopefully this package will help users who want to use sbctl on Debian, but don't feel like compiling it. I can tell you sbctl works the same way on Debian as it does on Arch, despite it not being documented on the Debian wiki. Thanks to sbctl, I have working secure boot on Debian on my laptop (which didn't come with Microsoft's keys)!