### PR TITLE
Update documentation for custom dbx

### DIFF
--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -54,8 +54,9 @@ EFI signing commands
                 This feature is experimental
 
         *-c*, *--custom*;;
-                Enroll custom KEK and db certificates from "/usr/share/secureboot/keys/custom/KEK/"
-                and "/usr/share/secureboot/keys/custom/db/", respectively.
+                Enroll custom KEK and db certificates from "/usr/share/secureboot/keys/custom/KEK/",
+                "/usr/share/secureboot/keys/custom/db/" and "/usr/share/secureboot/keys/custom/dbx/",
+                respectively.
 
         *-f*, *--firmware-builtin*;;
                 Enroll signatures from dbDefault, KEKDefault or PKDefault. This


### PR DESCRIPTION
The support was introduced in dae25b8 without documentation, since dbx was not mentioned at all in the manpage/news at that point in time.