### PR TITLE
keys.go: drop the keyUsage bitfield

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -59,7 +59,6 @@ func CreateKey(name string) ([]byte, []byte, error) {
 		SignatureAlgorithm: x509.SHA256WithRSA,
 		NotBefore:          time.Now(),
 		NotAfter:           time.Now().AddDate(5, 0, 0),
-		KeyUsage:           x509.KeyUsageDigitalSignature,
 		Subject: pkix.Name{
 			Country:    []string{name},
 			CommonName: name,


### PR DESCRIPTION
fixes https://github.com/Foxboron/sbctl/issues/102

been testing this for a while on my thinkpad t460s