### PR TITLE
`create-keys` allows for specifying an export directory

### DIFF
--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -8,21 +8,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	exportPath   string = sbctl.KeysPath
+	databasePath string = sbctl.DatabasePath
+)
+
 var createKeysCmd = &cobra.Command{
 	Use:   "create-keys",
 	Short: "Create a set of secure boot signing keys",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := sbctl.CreateDirectory(sbctl.KeysPath); err != nil {
+		if err := sbctl.CreateDirectory(exportPath); err != nil {
 			return err
 		}
-		uuid, err := sbctl.CreateGUID(sbctl.DatabasePath)
+		uuid, err := sbctl.CreateGUID(databasePath)
 		if err != nil {
 			return err
 		}
 		logging.Print("Created Owner UUID %s\n", uuid)
-		if !sbctl.CheckIfKeysInitialized(sbctl.KeysPath) {
+		if !sbctl.CheckIfKeysInitialized(exportPath) {
 			logging.Print("Creating secure boot keys...")
-			err := sbctl.InitializeSecureBootKeys(sbctl.KeysPath)
+			err := sbctl.InitializeSecureBootKeys(exportPath)
 			if err != nil {
 				logging.NotOk("")
 				return fmt.Errorf("couldn't initialize secure boot: %w", err)
@@ -36,7 +41,15 @@ var createKeysCmd = &cobra.Command{
 	},
 }
 
+func createKeysCmdFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+	f.StringVarP(&exportPath, "export", "e", "", "export file path. defaults to "+sbctl.KeysPath)
+	f.StringVarP(&databasePath, "database-path", "d", "", "location to create GUID file. defaults to "+sbctl.DatabasePath)
+}
+
 func init() {
+	createKeysCmdFlags(createKeysCmd)
+
 	CliCommands = append(CliCommands, cliCommand{
 		Cmd: createKeysCmd,
 	})

--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -29,8 +29,18 @@ EFI signing commands
         Creates a set of signing keys used to sign EFI binaries. Currently, it
         will create the following keys:
         * Platform Key
-        * Key Exchange key
+        * Key Exchange Key
         * Signature Database Key
+
+        *-e*, *--export*;;
+                The directory to persist the exported keys.
+
+                Default: "/usr/share/secureboot/keys/"
+
+        *-d*, *--database-path*;;
+                Path to save the GUID file when generating keys.
+
+                Default: "/usr/share/secureboot/"
 
 **enroll-keys**::
         Enrolls the creates key into the EFI variables. This puts the computer


### PR DESCRIPTION
To resolve https://github.com/Foxboron/sbctl/issues/258

This allows the end-user to specify an `export` path. Not entirely sure what the GUID is useful for, tbh, but since I didn't have a `/usr/share/secureboot/` directory, I was still having trouble running this command. I added the ability to specify the `database-path` too.