### PR TITLE
BUGFIX: f.StringVarP() was clearing the exportPath/databasePath strings

### DIFF
--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -43,8 +43,8 @@ var createKeysCmd = &cobra.Command{
 
 func createKeysCmdFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
-	f.StringVarP(&exportPath, "export", "e", "", "export file path. defaults to "+sbctl.KeysPath)
-	f.StringVarP(&databasePath, "database-path", "d", "", "location to create GUID file. defaults to "+sbctl.DatabasePath)
+	f.StringVarP(&exportPath, "export", "e", sbctl.KeysPath, "export file path. defaults to "+sbctl.KeysPath)
+	f.StringVarP(&databasePath, "database-path", "d", sbctl.DatabasePath, "location to create GUID file. defaults to "+sbctl.DatabasePath)
 }
 
 func init() {


### PR DESCRIPTION
I'm not sure how ```sbctl create``` ever worked with the default paths--- the var {} block initially sets exportPath/databasePath to the default values from the sbctl module, but then pflag.StringVarP() overwrote them with empty string passed in as the ```value``` parameter. From https://github.com/spf13/pflag/blob/master/string.go it looks like that has been the behavior for a long time.

Fixed by passing the values from sbctl as the initialization value in StringVarP().