### PR TITLE
Fixed typo, removed mention enroll-keys enables Secure Boot automatic…

### DIFF
--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -43,8 +43,7 @@ EFI signing commands
                 Default: "/usr/share/secureboot/"
 
 **enroll-keys**::
-        Enrolls the creates key into the EFI variables. This puts the computer
-        out of SetupMode and enables Secure Boot.
+        Enrolls the created key into the EFI variables. 
 
         Note that some devices have hardware firmware that is signed and
         validated when Secure Boot is enabled. Failing to validate this firmware


### PR DESCRIPTION
…ally

Huh, GitHub has a less than 80 character limit to commit messages.  

Per https://wiki.archlinux.org/title/Talk:Unified_Extensible_Firmware_Interface/Secure_Boot#Enrolling_keys_with_sbctl_enables_Secure_Boot, `enroll-keys` does **NOT** enable Secure Boot.  It still has to be done manually through the UEFI BIOS firmware settings.