### PR TITLE
Ensure file signing hook is run when initrd is rebuilt

### DIFF
--- a/contrib/mkinitcpio/sbctl
+++ b/contrib/mkinitcpio/sbctl
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 echo "Signing EFI binaries..."
 /usr/bin/sbctl sign-all -g

--- a/contrib/mkinitcpio/sbctl
+++ b/contrib/mkinitcpio/sbctl
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "Signing EFI binaries..."
+/usr/bin/sbctl sign-all -g

--- a/contrib/pacman/ZZ-sbctl.hook
+++ b/contrib/pacman/ZZ-sbctl.hook
@@ -7,10 +7,7 @@ Target = boot/*
 Target = efi/*
 Target = usr/lib/modules/*/vmlinuz
 Target = usr/lib/modules/*/extramodules/*
-Target = usr/lib/initcpio/*
 Target = usr/lib/**/efi/*.efi*
-Target = usr/lib/firmware/*
-Target = usr/src/*/dkms.conf
 
 [Action]
 Description = Signing EFI binaries...

--- a/contrib/pacman/ZZ-sbctl.hook
+++ b/contrib/pacman/ZZ-sbctl.hook
@@ -9,6 +9,8 @@ Target = usr/lib/modules/*/vmlinuz
 Target = usr/lib/modules/*/extramodules/*
 Target = usr/lib/initcpio/*
 Target = usr/lib/**/efi/*.efi*
+Target = usr/lib/firmware/*
+Target = usr/src/*/dkms.conf
 
 [Action]
 Description = Signing EFI binaries...


### PR DESCRIPTION
Initrd is rebuilt when a DKMS module or firmware package is installed or updated as of these commits to mkinitcpio: https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/aff81712789b9f2c1664fe1cfb5c1ecdbc5c993b https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/3576b03d29420ccd1913eaa18c7f8950e7de3103

Without this change, images created by mkinitcpio will not be automatically signed for secure boot in the events mentioned above.