### PR TITLE
Mention COPR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ For Gentoo Linux:
 # emerge --ask app-crypt/sbctl
 ```
 
+For Fedora Linux (unofficial package):
+```
+# dnf copr enable chenxiaolong/sbctl
+# dnf install sbctl
+```
+
 You can find a updated list of [sbctl packages on
 Repology](https://repology.org/project/sbctl/versions).
 


### PR DESCRIPTION
This package was originally part of [`secure-boot`](https://copr.fedorainfracloud.org/coprs/chenxiaolong/secure-boot/) in which the maintainer mentioned:

> [2023-11-12 Update]: This repo is deprecated because I have switched to using systemd-ukify for generating UKIs. Because sbctl is very useful on its own, **I will continue to package it in a [separate repo](https://copr.fedorainfracloud.org/coprs/chenxiaolong/sbctl/). Folks who currently use this repo should expect things to continue to work, though no further updates will be provided and repos for Fedora 40+ will not be created.**

I asked the maintainer if he'd mind if we added this to the official readme via email. Reply was:

> Sure, I don't mind at all. I actively use sbctl on all my machines, so I intend to keep maintaining the package for the foreseeable future (unless Fedora adds it to the official repos).