### PR TITLE
Add openSUSE to Installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,15 @@ For Gentoo Linux:
 # emerge --ask app-crypt/sbctl
 ```
 
+For openSUSE:
+```
+# zypper install sbctl
+```
+
 You can find a updated list of [sbctl packages on
 Repology](https://repology.org/project/sbctl/versions).
 
-In addition, sbctl is also available for [openSUSE (experimental) & Ubuntu
+In addition, sbctl is also available for [Ubuntu
 (unofficial)](https://software.opensuse.org/package/sbctl?search_term=sbctl).
 Follow the `Expert Download` links to find installation instructions according
 to your operating system.


### PR DESCRIPTION
Since 2023-11-21, openSUSE has shipped sbctl as part of the main repos.
See: [OBS request](https://build.opensuse.org/request/show/1127877)