### PR TITLE
Update the mkinitcpio post hook to only sign the kernel/UKI which is currently being built instead of all the files in the sbctl database

### DIFF
--- a/contrib/mkinitcpio/sbctl
+++ b/contrib/mkinitcpio/sbctl
@@ -1,3 +1,20 @@
 #!/usr/bin/bash
-echo "Signing EFI binaries..."
-/usr/bin/sbctl sign-all -g
+
+KERENEL_FILE="$1"
+UKI_FILE="$3"
+
+IMAGE_FILE="$KERENEL_FILE"
+if [ -n "$KERNELDESTINATION" ] && [ -f "$KERNELDESTINATION" ]; then
+    IMAGE_FILE="$KERNELDESTINATION"
+fi
+if [ -n "$UKI_FILE" ]; then
+    IMAGE_FILE="$UKI_FILE"
+fi
+
+if [ -z "$IMAGE_FILE" ]; then
+    echo "No kernel or UKI found for signing"
+    exit 0
+fi
+
+echo "Signing $IMAGE_FILE"
+sbctl sign -s "$IMAGE_FILE"


### PR DESCRIPTION
See #284 for details on the problem.

This PR updates the mkinitcpio post hook to only sign the kernel/UKI which is currently being built instead of all the files in the sbctl database.

References:
- https://man.archlinux.org/man/mkinitcpio.8#ABOUT_POST_HOOKS
- https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Signing_the_kernel_with_a_mkinitcpio_post_hook
- https://wiki.archlinux.org/title/Unified_kernel_image#Signing_the_UKIs_for_Secure_Boot

Fixes #284