### PR TITLE
only remove entries if they are there

### DIFF
--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -39,8 +39,10 @@ add)
 	sbctl sign -s "$IMAGE_FILE" 1>/dev/null
 	;;
 remove)
-	[ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
+	if [[ -e "$IMAGE_FILE" ]]; then
+	    [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
 		printf 'sbctl: Removing kernel %s from signing database\n' "$IMAGE_FILE"
-	sbctl remove-file "$IMAGE_FILE" 1>/dev/null
+	    sbctl remove-file "$IMAGE_FILE" 1>/dev/null
+	fi
 	;;
 esac


### PR DESCRIPTION
This fixes a problem on fedora.
If this check is not done, removing a kernel will fail and the rpmdb will become corrupt, showing multiple entries. (use: "rpm -e --allmatches" to remove them)

I bet this hack is imperfect, but it sure is a step in the right direction.