### PR TITLE
Add list-enrolled-keys command

### DIFF
--- a/cmd/sbctl/list-enrolled-keys.go
+++ b/cmd/sbctl/list-enrolled-keys.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	"github.com/foxboron/go-uefi/efi"
+	"github.com/foxboron/go-uefi/efi/signature"
+	"github.com/foxboron/go-uefi/efi/util"
+	"github.com/spf13/cobra"
+)
+
+var listKeysCmd = &cobra.Command{
+	Use: "list-enrolled-keys",
+	Aliases: []string{
+		"ls-enrolled-keys",
+	},
+	Short: "List enrolled keys on the system",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		certList := map[string]([]*x509.Certificate){}
+
+		pk, err := efi.GetPK()
+		if err != nil {
+			return err
+		}
+		kek, err := efi.GetKEK()
+		if err != nil {
+			return err
+		}
+		db, err := efi.Getdb()
+		if err != nil {
+			return err
+		}
+
+		certList["PK"] = ExtractCertsFromSignatureDatabase(pk)
+		certList["KEK"] = ExtractCertsFromSignatureDatabase(kek)
+		certList["DB"] = ExtractCertsFromSignatureDatabase(db)
+
+		if cmdOptions.JsonOutput {
+			return JsonOut(certList)
+		}
+
+		printCertsPlainText(certList)
+
+		return nil
+	},
+}
+
+func init() {
+	CliCommands = append(CliCommands, cliCommand{
+		Cmd: listKeysCmd,
+	})
+}
+
+// ExtractCertsFromSignatureDatabase returns a []*x509.Certificate from a *signature.SignatureDatabase
+func ExtractCertsFromSignatureDatabase(database *signature.SignatureDatabase) []*x509.Certificate {
+	var result []*x509.Certificate
+	for _, k := range *database {
+		if isValidSignature(k.SignatureType) {
+			for _, k1 := range k.Signatures {
+				// Note the S at the end of the function, we are parsing multiple certs, not just one
+				certificates, err := x509.ParseCertificates(k1.Data)
+				if err != nil {
+					continue
+				}
+				result = append(result, certificates...)
+			}
+		}
+	}
+	return result
+}
+
+// isValidSignature identifies a signature based as a DER-encoded X.509 certificate
+func isValidSignature(sign util.EFIGUID) bool {
+	return sign == signature.CERT_X509_GUID
+}
+
+func printCertsPlainText(certList map[string][]*x509.Certificate) {
+	for db, certs := range certList {
+		fmt.Printf("%s:\n", db)
+		for _, c := range certs {
+			fmt.Printf("  %s\n", c.Issuer.CommonName)
+		}
+	}
+}


### PR DESCRIPTION
to list certificates that are already enrolled on the current system

Background:

In the [Kairos project](https://github.com/kairos-io/kairos/) we need a simple way for our users to enroll custom keys to the firmware. We also need to help them [revoke certain keys](https://github.com/kairos-io/kairos/issues/2429) later. In general, we need a tool that allows them to manage the enrolled keys (list, add, delete).

It [was suggested that sbctl](https://github.com/kairos-io/kairos/issues/2486#issuecomment-2066073266) could satisfy these (or some of these) requirements. This is a first PR to try this option.

-------

I tried to follow the naming conventions of the other commands to stay consistent but we could discuss a different way to structure this new command to allow us to later add  subcommands for other operations (e.g. `sbctl enrolled-keys list` , `sbctl enrolled-keys add` etc)

I had a look at the integration tests in order to add one for this command but I didn't find a simple way to run them locally and I don't see those running in Github actions either. Let me know if I missed something. If you don't mind me adding testing related changes to this PR, I could try to make those run locally in a streamlined way. We also do integration testing using VMs in Kairos but I'm afraid the testing related changes would be more than what this PR introduces already. Alternatively, I could try to introduce the testing changes to run integration tests in another PR and then get back to this one to consume.

Let us know what you think!


Note: The code in this PR is mostly a copy of what we have already implemented in Kairos: https://github.com/kairos-io/kairos-sdk/pull/103/files