### PR TITLE
[WIP] Introduce prepare-integration make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ lint:
 test:
 	go test -v ./...
 
+.PHONY: prepare-integration
+prepare-integration:
+	docker run --privileged -v ${PWD}/tests/:/workdir -w /workdir archlinux ./make_image.sh
+
 .PHONY: integration
 integration:
 	go test -v tests/integration_test.go

--- a/go.sum
+++ b/go.sum
@@ -217,8 +217,6 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
-github.com/foxboron/go-uefi v0.0.0-20230217160721-375279dfc837 h1:JAEqMMcWSvLghXL8W5w4Bp1mRL8x35pCW9OlpZnKOB0=
-github.com/foxboron/go-uefi v0.0.0-20230217160721-375279dfc837/go.mod h1:VdozURTQHi5Rs54l+4Szi3yIJQDMfXXYrRLAjKKowWI=
 github.com/foxboron/go-uefi v0.0.0-20230808201820-18b9ba9cd4c3 h1:SJMQFT74bCrP+kQ24oWhmuyPFHDTavrd3JMIe//2NhU=
 github.com/foxboron/go-uefi v0.0.0-20230808201820-18b9ba9cd4c3/go.mod h1:VdozURTQHi5Rs54l+4Szi3yIJQDMfXXYrRLAjKKowWI=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=

--- a/tests/make_image.sh
+++ b/tests/make_image.sh
@@ -1,24 +1,48 @@
 #!/bin/bash
-dd if=/dev/zero of=rootfs.raw bs=1G count=1
-mkfs.ext4 rootfs.raw
-sudo losetup -fP rootfs.raw
-mkdir rootfs
-sudo mount /dev/loop0 rootfs
-sudo pacstrap rootfs base openssh
+
+# TODO: Move to a pre-built image?
+prepareDeps(){
+  pacman -Sy
+  pacman -S --noconfirm sudo qemu-img arch-install-scripts linux dracut
+}
+
+cleanupPreviousRuns() {
+  rm -rf "${OUTDIR}/rootfs"
+  rm -rf "${OUTDIR}/rootfs.raw"
+}
+
+set -ex
+
+export WORKDIR=/workdir
+export OUTDIR=$WORKDIR/kernel
+
+prepareDeps
+cleanupPreviousRuns
+
+# Copy a kernel file too
+find /usr/lib/modules/ -name "vmlinuz" -type f -exec cp {} $OUTDIR/bzImage \; -quit
+
+dd if=/dev/zero of="${OUTDIR}/rootfs.raw" bs=1G count=1
+mkfs.ext4 "${OUTDIR}/rootfs.raw"
+sudo losetup -fP "${OUTDIR}/rootfs.raw"
+mkdir "${OUTDIR}/rootfs"
+sudo mount /dev/loop0 "${OUTDIR}/rootfs"
+sudo pacstrap "${OUTDIR}/rootfs" base openssh
 
 echo "[Match]
 Name=enp0s3
 
 [Network]
-DHCP=yes" | sudo tee rootfs/etc/systemd/network/20-wired.network
+DHCP=yes" | sudo tee "${OUTDIR}/rootfs/etc/systemd/network/20-wired.network"
 
-sudo sed -i '/^root/ { s/:x:/::/ }' rootfs/etc/passwd
-sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' rootfs/etc/ssh/sshd_config
-sudo sed -i 's/#PermitEmptyPasswords no/PermitEmptyPasswords yes/' rootfs/etc/ssh/sshd_config
+sudo sed -i '/^root/ { s/:x:/::/ }' "${OUTDIR}/rootfs/etc/passwd"
+sudo sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' "${OUTDIR}/rootfs/etc/ssh/sshd_config"
+sudo sed -i 's/#PermitEmptyPasswords no/PermitEmptyPasswords yes/' "${OUTDIR}/rootfs/etc/ssh/sshd_config"
 
-sudo arch-chroot rootfs systemctl enable sshd systemd-networkd
-sudo rm rootfs/var/cache/pacman/pkg/*
-sudo umount rootfs
+sudo arch-chroot "${OUTDIR}/rootfs" systemctl enable sshd systemd-networkd
+sudo rm "${OUTDIR}"/rootfs/var/cache/pacman/pkg/*
+sudo umount "${OUTDIR}"/rootfs
 sudo losetup -d /dev/loop0
-rm -r rootfs
-qemu-img create -o backing_file=rootfs.raw,backing_fmt=raw -f qcow2 rootfs.cow
+rm -r "${OUTDIR}"/rootfs
+qemu-img create -o backing_file=rootfs.raw,backing_fmt=raw -f qcow2 "${OUTDIR}"/rootfs.cow
+chmod 777 "${OUTDIR}"/rootfs.*

--- a/tests/utils/utils.go
+++ b/tests/utils/utils.go
@@ -29,7 +29,7 @@ func StartOVMF(conf TestConfig) *vmtest.Qemu {
 	}
 	opts := vmtest.QemuOptions{
 		Params:  params,
-		Verbose: false, //testing.Verbose(),
+		Verbose: testing.Verbose(),
 		Timeout: 50 * time.Second,
 	}
 	// Run QEMU instance
@@ -73,8 +73,8 @@ func StartVM(conf *TestConfig) *TestVM {
 		Kernel:          "kernel/bzImage",
 		Params:          params,
 		Disks:           []vmtest.QemuDisk{{Path: "kernel/rootfs.cow", Format: "qcow2"}},
-		Append:          []string{"root=/dev/sda", "quiet", "rw"},
-		Verbose:         false, //testing.Verbose()
+		Append:          []string{"root=/dev/vda", "quiet", "rw"},
+		Verbose:         testing.Verbose(),
 		Timeout:         50 * time.Second,
 	}
 	// Run QEMU instance


### PR DESCRIPTION
to prepare the VM filesystem for the tests.
This target is suppused to be run like so:

make prepare-integration integration

but currently the filesystem it creates is not bootable for some reason.

@Foxboron looking at the code it seems that there is some way to run the integration test but it's relying on things outside git. I tried to fill in the missing parts by wrapping the make_image.sh script in a docker command that would make it possible to run it locally.

I remember you mentioned u-root being used in `go-uefi` so I wonder if I should ditch this and try to use `u-root` to build an initramfs that has sbctl in it. What do you think? I'm also fine dropping this completely until you find time to work on it yourself. I only mean to help, no pressure :). 