### PR TITLE
Add Option ROM warning to Usage section of the manpage

### DIFF
--- a/docs/sbctl.8.txt
+++ b/docs/sbctl.8.txt
@@ -295,7 +295,7 @@ If this step is not completed, enrolling custom keys will be rejected by the fir
 Next is creating the keys for secure boot. 'create-keys' creates the key
 hierarchy needed for secure boot into "/usr/share/secureboot".
 
-        $ sbctl create-keys
+        # sbctl create-keys
         Created Owner UUID a9fbbdb7-a05f-48d5-b63a-08c5df45ee70
         Creating secure boot keys...✔
         Secure boot keys created!
@@ -305,9 +305,12 @@ on a live system instead of having to boot or run a key management tool from the
 UEFI shell.
 
 'Note': This can fail because of firmware issues and unique options in the
-machine BIOS menu.
+machine BIOS menu. Also, some devices have hardware firmware that is signed and
+validated when Secure Boot is enabled. Failing to validate this firmware could
+brick devices. It's recommended to enroll your own keys with Microsoft
+certificates using the '-m' option. See **Option ROM*** above.
 
-        $ sbctl enroll-keys
+        # sbctl enroll-keys
         Enrolling keys to EFI variables...✔
         Enrolled keys to the EFI variables!
 
@@ -323,19 +326,19 @@ store the file path, so we don't need to manually sign it later.
 Note that *sbctl* can only keep track of file paths. On versioned kernels this
 might prove tricky.
 
-        $ sbctl sign --save /efi/vmlinuz-linux
+        # sbctl sign --save /efi/vmlinuz-linux
         ✔ Signed /efi/vmlinuz-linux
 
 Next is to sign the bootloader. This can usually be found on the standard path
 below, but might differ between installations.
 
-        $ sbctl sign --save /efi/EFI/BOOT/BOOTX64.EFI
+        # sbctl sign --save /efi/EFI/BOOT/BOOTX64.EFI
         ✔ Signed /efi/EFI/BOOT/BOOTX64.EFI
 
 *sbctl* is able to find and verify the ESP, along with any saved files to verify
 we have signed the files we need.
 
-        $ sbctl verify
+        # sbctl verify
         Verifying file database and EFI images in /efi...
         ✔ /efi/EFI/BOOT/BOOTX64.EFI is signed
         ✔ /efi/vmlinuz-linux is signed
@@ -353,7 +356,7 @@ Secure Boot or enter User Mode in the firmware.
 When we do a system update, we can run 'sign-all' to resign all the saved files
 from earlier.
 
-        $ sbctl sign-all
+        # sbctl sign-all
         File has already been signed /boot/vmlinuz-linux
         ✓ Signed /efi/EFI/BOOT/BOOTX64.EFI
 
@@ -362,7 +365,7 @@ the initramfs, kernel and cmdline into one executable which can be signed for
 secure boot. This allows you to authenticate larger parts of the bootchain
 instead of only signing the kernel.
 
-        $ sbctl bundle -i /boot/intel-ucode.img
+        # sbctl bundle -i /boot/intel-ucode.img
                        -l /usr/share/systemd/bootctl/splash-arch.bmp
                        -k /boot/vmlinuz-linux
                        -f /boot/initramfs-linux-lts.img


### PR DESCRIPTION
The text in the usage section did not mention that some firmware might need Microsoft certificates as well, so I copied pasted it from line 48.

I noticed [on a Reddit comment](https://reddit.com/r/archlinux/comments/uwytxm/bios_brick_after_using_sbctl/i9wvbhp/?context=3) though that there's a warning if option ROM is detected, so this warning might be unnecessary. However, I also found issue #212, so I'm not sure if option ROM will always be reliably detected. Feel free to reject this PR if there is already a reliable warning when you have option ROM (I don't so I can't test).

I also did not include the `-m` flag by default in the `sbctl enroll-keys`, since I was not sure how widespread OpROMs are.

Some `$`s were also changed to `#`s to indicate that they should be run as root (didn't want to make a separate PR for changing 7 characters). I'm not familiar with asciidoc, so hopefully `#`s don't have special meaning.