### PR TITLE
Add export-enrolled-keys command

### DIFF
--- a/cmd/sbctl/export-enrolled-keys.go
+++ b/cmd/sbctl/export-enrolled-keys.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/foxboron/go-uefi/efi"
+	"github.com/foxboron/go-uefi/efi/signature"
+	"github.com/spf13/cobra"
+)
+
+type DerList map[string][]uint8
+
+var exportDir, format string
+
+var exportEnrolledKeysCmd = &cobra.Command{
+	Use:   "export-enrolled-keys",
+	Short: "Export already enrolled keys from the system",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if exportDir == "" {
+			fmt.Println("--dir should be set")
+			os.Exit(1)
+		}
+
+		var err error
+		allCerts := map[string]DerList{}
+
+		pk, err := efi.GetPK()
+		if err != nil {
+			return err
+		}
+		kek, err := efi.GetKEK()
+		if err != nil {
+			return err
+		}
+		db, err := efi.Getdb()
+		if err != nil {
+			return err
+		}
+
+		exportDir, err = ensureDir(exportDir)
+		if err != nil {
+			return fmt.Errorf("creating the output directory: %w", err)
+		}
+
+		switch format {
+		case "der":
+			allCerts["PK"] = ExtractDerFromSignatureDatabase(pk)
+			allCerts["KEK"] = ExtractDerFromSignatureDatabase(kek)
+			allCerts["DB"] = ExtractDerFromSignatureDatabase(db)
+
+			if err := writeDerFiles(allCerts, exportDir); err != nil {
+				return fmt.Errorf("writing the certificates: %w", err)
+			}
+		case "esl":
+			if err := os.WriteFile(filepath.Join(exportDir, "db.esl"), db.Bytes(), 0o644); err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join(exportDir, "KEK.esl"), kek.Bytes(), 0o644); err != nil {
+				return err
+			}
+			if err := os.WriteFile(filepath.Join(exportDir, "PK.esl"), pk.Bytes(), 0o644); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown format %s", format)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	exportEnrolledKeysCmd.Flags().StringVar(&exportDir, "dir", "", "directory to write the exported certificates")
+	exportEnrolledKeysCmd.Flags().StringVar(&format, "format", "der", "the export format. One of \"der\", \"esl\"")
+
+	CliCommands = append(CliCommands, cliCommand{
+		Cmd: exportEnrolledKeysCmd,
+	})
+}
+
+func ExtractDerFromSignatureDatabase(db *signature.SignatureDatabase) DerList {
+	result := DerList{}
+
+	for _, c := range *db {
+		for _, s := range c.Signatures {
+			switch c.SignatureType {
+			case signature.CERT_X509_GUID, signature.CERT_SHA256_GUID:
+				certificates, err := x509.ParseCertificates(s.Data)
+				if err != nil {
+					fmt.Println("warning: " + err.Error())
+					continue
+				}
+				for _, c := range certificates {
+					result[fileNameForCertificate(c)] = s.Data
+				}
+			default:
+				fmt.Printf("warning: format not implemented - %s\n", c.SignatureType.Format())
+				continue
+			}
+		}
+	}
+
+	return result
+}
+
+func fileNameForCertificate(c *x509.Certificate) string {
+	return fmt.Sprintf("%s_%s",
+		strings.ReplaceAll(c.Issuer.CommonName, " ", "_"),
+		c.SerialNumber.String(),
+	)
+}
+
+func writeDerFiles(allCerts map[string]DerList, outDir string) error {
+	for t, certList := range allCerts {
+		certDir := filepath.Join(outDir, t)
+		if err := os.MkdirAll(certDir, os.ModePerm); err != nil {
+			return fmt.Errorf("creating directory %s: %w", certDir, err)
+		}
+		for fileName, c := range certList {
+			certPath := filepath.Join(certDir, fileName) + ".der"
+			if err := os.WriteFile(certPath, []byte(c), os.ModePerm); err != nil {
+				return fmt.Errorf("writing file %s: %w", certPath, err)
+			}
+		}
+	}
+	return nil
+}
+
+// ensureDir resolved any relative path and creates the directory if it does not
+// exist. It returns the aboslute path to the created directory or an error if one
+// occurs.
+func ensureDir(dir string) (string, error) {
+	if !filepath.IsAbs(dir) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		// Resolve the relative path
+		dir = filepath.Join(wd, dir)
+	}
+
+	if _, err := os.Stat(dir); err == nil {
+		return "", fmt.Errorf("directory already exists")
+	}
+
+	return dir, os.MkdirAll(dir, 0755)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/foxboron/sbctl
 go 1.20
 
 require (
-	github.com/anatol/vmtest v0.0.0-20220413190228-7a42f1f6d7b8
 	github.com/fatih/color v1.13.0
 	github.com/foxboron/go-uefi v0.0.0-20230808201820-18b9ba9cd4c3
 	github.com/google/go-attestation v0.5.1
@@ -12,7 +11,6 @@ require (
 	github.com/onsi/gomega v1.7.1
 	github.com/spf13/afero v1.9.3
 	github.com/spf13/cobra v1.1.3
-	golang.org/x/crypto v0.16.0
 	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848
 	golang.org/x/sys v0.15.0
 )
@@ -45,6 +43,7 @@ require (
 	github.com/ulikunitz/xz v0.5.11 // indirect
 	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
+	golang.org/x/crypto v0.16.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/anatol/vmtest v0.0.0-20220413190228-7a42f1f6d7b8 h1:t4JGeY9oaF5LB4Rdx9e2wARRRPAYt8Ow4eCf5SwO3fA=
-github.com/anatol/vmtest v0.0.0-20220413190228-7a42f1f6d7b8/go.mod h1:oPm5wWoqTSkeoPe1Q3sPryTK8o24Jcbwh8dKOiiIobk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
@@ -1045,7 +1043,6 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -62,6 +62,7 @@ func TestEnrollement(t *testing.T) {
 		t.Run("Enroll keys", vm.RunTests("github.com/foxboron/sbctl/tests/integrations/enroll_keys"))
 		t.Run("Secure boot enabled", vm.RunTests("github.com/foxboron/sbctl/tests/integrations/secure_boot_enabled"))
 		t.Run("List enrolled keys", vm.RunTests("github.com/foxboron/sbctl/tests/integrations/list_enrolled_keys"))
+		t.Run("Export enrolled keys", vm.RunTests("github.com/foxboron/sbctl/tests/integrations/export_enrolled_keys"))
 	})
 }
 

--- a/tests/integrations/export_enrolled_keys/export_enrolled_keys_test.go
+++ b/tests/integrations/export_enrolled_keys/export_enrolled_keys_test.go
@@ -1,0 +1,81 @@
+//go:build integration
+// +build integration
+
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/foxboron/go-uefi/efi/signature"
+	"github.com/foxboron/sbctl/tests/utils"
+	"github.com/hugelgupf/vmtest/guest"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestExportEnrolledKeysDer(t *testing.T) {
+	g := NewWithT(t)
+
+	guest.SkipIfNotInVM(t)
+
+	out, err := utils.ExecWithOutput("sbctl export-enrolled-keys --dir /tmp/exported-der --format der")
+	g.Expect(err).ToNot(HaveOccurred(), out)
+
+	platformKey, err := findFileByPattern("/tmp/exported-der/PK", ".*Platform.*.der")
+	g.Expect(err).ToNot(HaveOccurred())
+
+	derBytes, err := os.ReadFile(platformKey)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	cert, err := x509.ParseCertificate(derBytes)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	g.Expect(cert.Issuer.String()).To(MatchRegexp("CN=Platform Key,C=Platform Key"))
+}
+
+func TestExportEnrolledKeysEsl(t *testing.T) {
+	g := NewWithT(t)
+
+	guest.SkipIfNotInVM(t)
+
+	out, err := utils.ExecWithOutput("sbctl export-enrolled-keys --dir /tmp/exported-esl --format esl")
+	g.Expect(err).ToNot(HaveOccurred(), out)
+
+	eslReader, err := os.Open("/tmp/exported-esl/db.esl")
+	g.Expect(err).ToNot(HaveOccurred())
+	defer eslReader.Close()
+
+	sl, err := signature.ReadSignatureList(eslReader)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	s := sl.Signatures[0]
+	certificates, err := x509.ParseCertificates(s.Data)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(certificates[0].Issuer.CommonName).To(Equal("Database Key"))
+}
+
+func findFileByPattern(dirPath string, pattern string) (string, error) {
+	files, err := os.ReadDir(dirPath)
+	if err != nil {
+		return "", err
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
+
+	for _, file := range files {
+		fmt.Printf("file.Name() = %+v\n", file.Name())
+		if !file.IsDir() && re.MatchString(file.Name()) {
+			return filepath.Join(dirPath, file.Name()), nil
+		}
+	}
+
+	return "", fmt.Errorf("no file matching pattern '%s' found in directory '%s'", pattern, dirPath)
+}


### PR DESCRIPTION
This PR introduces an `export-enrolled-keys` command that allows the user to export the already enrolled keys to a directory for backup reasons (e.g. before making any changes on new hardware) and to prepare a directory that can be used as a "custom certs" when enrolling keys.

User scenario:

- User buys some new hardware with MS and vendor keys already enrolled
- User backs up the built-in keys using this new command
- User generates new keys (intended to sign their own OSes)
- User puts the machine in "setup mode" by deleting PK, KEK and db from bios
- User enrolls the new keys including the original ones as "custom keys"

This PR is only one of the things needed to implement the above scenario. Currently the export directory structure is the one expected by the `enroll-keys` command but the location is arbitrary. The user would have to copy the directory to the appropriate location (the db directory) in order to be read by the "enroll-keys" command.

In my opinion, it's the `enroll-keys` command that should be changed to be more flexible and read keys from arbitrary locations but this can be discussed on another ticket/PR.

Note: I would have written a test for this but waiting for this refactoring first: https://github.com/Foxboron/sbctl/pull/302

I'm opening this draft PR to collect some early feedback, until I can write the tests.