### PR TITLE
nit(91-sbctl.install): consistent syntax for tests

### DIFF
--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -31,7 +31,7 @@ add)
 
 	# exit without error if keys don't exist
 	# https://github.com/Foxboron/sbctl/issues/187
-	if ! test -d /usr/share/secureboot/keys; then
+	if ! [ -d /usr/share/secureboot/keys ]; then
 		echo "Secureboot key directory doesn't exist, not signing!"
 		exit 0
 	fi
@@ -39,10 +39,10 @@ add)
 	sbctl sign -s "$IMAGE_FILE" 1>/dev/null
 	;;
 remove)
-	if [[ -e "$IMAGE_FILE" ]]; then
-	    [ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
-		printf 'sbctl: Removing kernel %s from signing database\n' "$IMAGE_FILE"
-	    sbctl remove-file "$IMAGE_FILE" 1>/dev/null
+	if [ -e "$IMAGE_FILE" ]; then
+		[ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
+			printf 'sbctl: Removing kernel %s from signing database\n' "$IMAGE_FILE"
+		sbctl remove-file "$IMAGE_FILE" 1>/dev/null
 	fi
 	;;
 esac


### PR DESCRIPTION
Unifies usage of testing commands like `[]`, `test`, and `[[]]` to just
use `[]` everywhere. This also improves compatibility, as `[[]]` is not
available in POSIX sh.

N.B.: the script uses `#!/bin/sh`, so using `[[]]` as before can cause crashes
if the system has a symlink `sh -> dash`. This could also be fixed by changing
the shebang to use `bash` instead.
