### PR TITLE
91-sbctl.install: Unconditionally remove file from database

### DIFF
--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -39,10 +39,8 @@ add)
 	sbctl sign "$IMAGE_FILE" 1>/dev/null
 	;;
 remove)
-	if [ -e "$IMAGE_FILE" ]; then
-		[ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
-			printf 'sbctl: Removing kernel %s from signing database\n' "$IMAGE_FILE"
-		sbctl remove-file "$IMAGE_FILE" 1>/dev/null
-	fi
+	[ "$KERNEL_INSTALL_VERBOSE" -gt 0 ] &&
+		printf 'sbctl: Removing kernel %s from signing database\n' "$IMAGE_FILE"
+	sbctl remove-file "$IMAGE_FILE" 1>/dev/null || :
 	;;
 esac


### PR DESCRIPTION
This partially undoes 5106d1ef8aaf72e545eb86d4a1ba0ca42996f1e4, but avoids that problem by ignoring non-zero exit statuses from `sbctl remove-file`. That commit stopped the script from failing when uninstalling a kernel where the UKI wasn't in sbctl's database. However, it causes the UKI to never be removed from the database if UKI removal is done by a script that runs before `91-sbctl.install`.

This is the case with systemd-ukify's `60-ukify.install` and systemd's `90-uki-copy.install`. By the time that `91-sbctl.install` runs during kernel removal, `90-uki-copy.install` will have already deleted the UKI.