### PR TITLE
sbctl.hook: quieten output to reduce terminal spam

### DIFF
--- a/contrib/pacman/ZZ-sbctl.hook
+++ b/contrib/pacman/ZZ-sbctl.hook
@@ -12,4 +12,4 @@ Target = usr/lib/**/efi/*.efi*
 [Action]
 Description = Signing EFI binaries...
 When = PostTransaction
-Exec = /usr/bin/sbctl sign-all -g
+Exec = /usr/bin/sbctl sign-all -g --quiet


### PR DESCRIPTION
For systems dual-booting Windows, there are a large number of signed EFI files. Avoid outputting "File has already been signed" for each of them.