### PR TITLE
Read output file path from db if output not specified

### DIFF
--- a/cmd/sbctl/sign.go
+++ b/cmd/sbctl/sign.go
@@ -38,6 +38,21 @@ var signCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		// Get output path from database for file if output not specified
+		if output == "" {
+			files, err := sbctl.ReadFileDatabase(state.Fs, state.Config.FilesDb)
+			if err != nil {
+				return err
+			}
+			for _, entry := range files {
+				if entry.File == file {
+					logging.Print("Using output file from database\n")
+					output = entry.OutputFile
+					break
+				}
+			}
+		}
+
 		if output == "" {
 			output = file
 			rules = append(rules, lsm.TruncFile(file).IgnoreIfMissing())

--- a/cmd/sbctl/sign.go
+++ b/cmd/sbctl/sign.go
@@ -46,7 +46,6 @@ var signCmd = &cobra.Command{
 			}
 			for _, entry := range files {
 				if entry.File == file {
-					logging.Print("Using output file from database\n")
 					output = entry.OutputFile
 					break
 				}


### PR DESCRIPTION
The mkinitcpio hook runs `sbctl sign "$IMAGE_FILE"` and has no way to know the output file path for the corresponding image file. This results in signing in place which may break booting for those who with different locations for signed and unsigned UKIs.

The sign command should check if the given file is in the database and use the saved output file path.