### PR TITLE
fix: allow -a/--append without force

### DIFF
--- a/cmd/sbctl/enroll-keys.go
+++ b/cmd/sbctl/enroll-keys.go
@@ -310,7 +310,7 @@ func RunEnrollKeys(state *config.State) error {
 			return err
 		}
 	}
-	if !enrollKeysCmdOptions.Force && !enrollKeysCmdOptions.TPMEventlogChecksums && !enrollKeysCmdOptions.MicrosoftKeys {
+	if !enrollKeysCmdOptions.Force && !enrollKeysCmdOptions.TPMEventlogChecksums && !enrollKeysCmdOptions.MicrosoftKeys && !enrollKeysCmdOptions.Append {
 		if err := sbctl.CheckEventlogOprom(state.Fs, systemEventlog); err != nil {
 			return err
 		}


### PR DESCRIPTION
Appending keys can’t break a working system.
My Thinkpad T14s Gen 3 doesn’t clear the keys when entering setup mode, but even if it does, sbctl isn’t responsible for breaking the system.

It would be good to know if there are systems that clear all keys when entering setup mode. If there are many then it’d probably be best to leave it as-is.
=> please check this :)

I could check 3 systems:
- the mentioned thinkpad t14s gen3 does support setup mode and does not clear the keys
- both an msi and a tuf gaming (asus) motherboard supports secure boot but not setup mode.