### PR TITLE
add usr/share/**/*.efi* to paths for pacman hook

### DIFF
--- a/contrib/pacman/ZZ-sbctl.hook
+++ b/contrib/pacman/ZZ-sbctl.hook
@@ -8,6 +8,7 @@ Target = efi/*
 Target = usr/lib/modules/*/vmlinuz
 Target = usr/lib/modules/*/extramodules/*
 Target = usr/lib/**/efi/*.efi*
+Target = usr/share/**/*.efi*
 
 [Action]
 Description = Signing EFI binaries...


### PR DESCRIPTION
REFind is installed to /usr/share/refind/