### PR TITLE
build.yml: bump actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: sbctl-binaries-*
+          name: sbctl-binaries-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           path: sbctl-*
   upload:
     name: Upload release binaries
@@ -57,7 +57,7 @@ jobs:
       - name: Download workflow artifacts
         uses: actions/download-artifact@v4
         with:
-          name: sbctl-binaries-*
+          name: sbctl-binaries-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           merge-multiple: true
       - name: Upload release artifacts
         run: gh release upload "$GITHUB_REF_NAME" sbctl-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Download workflow artifacts
         uses: actions/download-artifact@v4
         with:
-          name: sbctl-binaries 
+          name: sbctl-binaries-*
+          merge-multiple: true
       - name: Upload release artifacts
         run: gh release upload "$GITHUB_REF_NAME" sbctl-*
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: sbctl-binaries
+          name: sbctl-binaries-*
           path: sbctl-*
   upload:
     name: Upload release binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
           GOARCH: ${{ matrix.GOARCH }}
           GOARM: ${{ matrix.GOARM }}
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sbctl-binaries
           path: sbctl-*
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download workflow artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: sbctl-binaries 
       - name: Upload release artifacts


### PR DESCRIPTION
Just update `upload-artifact@v2` to `upload-artifact@v4` due to: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/