### PR TITLE
gitignore: add generated man pages in section 5.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 tags
 releases/*
 /sbctl
+docs/*.5
 docs/*.8
 rootfs*
 VERSION


### PR DESCRIPTION
Currently this only matches sbctl.conf.5