### PR TITLE
Fix input/output file comparison when signing

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -66,11 +66,7 @@ func SignFile(state *config.State, kh *backend.KeyHierarchy, ev hierarchy.Hierar
 
 	// Check if the files are identical
 	if file != output {
-		if _, err := state.Fs.Stat(output); errors.Is(err, os.ErrExist) {
-			outputFile, err := state.Fs.Open(output)
-			if err != nil {
-				return err
-			}
+		if outputFile, err := state.Fs.Open(output); err == nil {
 			defer outputFile.Close()
 			outputBinary, err := authenticode.Parse(outputFile)
 			if err != nil {


### PR DESCRIPTION
`Stat` doesn't return `ErrExist` error, so this line is always false. We also don't need any stats for the output file, so we can just try to open the file, and continue the comparison with the input file if there is no error opening it.