### PR TITLE
sbctl setup migrate: fix typo

### DIFF
--- a/cmd/sbctl/setup.go
+++ b/cmd/sbctl/setup.go
@@ -154,7 +154,7 @@ func SetupInstallation(state *config.State) error {
 
 func MigrateSetup(state *config.State) error {
 	if !state.IsInstalled() {
-		return fmt.Errorf("sbctl is not installd")
+		return fmt.Errorf("sbctl is not installed")
 	}
 
 	newConf := config.DefaultConfig()


### PR DESCRIPTION
When running `sbctl sbctl setup --migrate`, the output if sbctl isn't installed is `sbctl is not installd`, this PR fixes the typo.