### PR TITLE
sbctl: fix typos

### DIFF
--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -105,7 +105,7 @@ func createKeysCmdFlags(cmd *cobra.Command) {
 	f.StringVarP(&Keytype, "keytype", "", "", "key type for all keys")
 	f.StringVarP(&PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
 	f.StringVarP(&KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
-	f.StringVarP(&DbKeytype, "db-keytype", "", "", "db key type (defualt: file)")
+	f.StringVarP(&DbKeytype, "db-keytype", "", "", "db key type (default: file)")
 }
 
 func init() {

--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -324,7 +324,7 @@ func rotateKeysCmdFlags(cmd *cobra.Command) {
 	f.StringVarP(&rotateKeysCmdOptions.Keytype, "keytype", "", "", "key type for all keys")
 	f.StringVarP(&rotateKeysCmdOptions.PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
 	f.StringVarP(&rotateKeysCmdOptions.KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
-	f.StringVarP(&rotateKeysCmdOptions.DbKeytype, "db-keytype", "", "", "db key type (defualt: file)")
+	f.StringVarP(&rotateKeysCmdOptions.DbKeytype, "db-keytype", "", "", "db key type (default: file)")
 }
 
 func init() {


### PR DESCRIPTION
While reading the `--help` pages. I noticed several typos.

I fixed every typo occurence of "defualt" -> "default"