### PR TITLE
initial yubikey piv support

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -299,18 +299,16 @@ func GetKeyHierarchy(vfs afero.Fs, state *config.State) (*KeyHierarchy, error) {
 }
 
 func GetBackendType(b []byte) (BackendType, error) {
-	block, _ := pem.Decode(b)
-	if block == nil {
-		//the yubikey data is json
+	if json.Valid(b) {
 		var yubiData YubikeyData
 		err := json.Unmarshal(b, &yubiData)
 		if err != nil {
 			logging.Errorf("Error unmarshalling Yubikey: %v\n", err)
 			return "", err
 		}
-		fmt.Printf("unmarshalled!: %s\n", b)
 		return YubikeyBackend, nil
 	} else {
+		block, _ := pem.Decode(b)
 		// TODO: Add TSS2 keys
 		switch block.Type {
 		case "PRIVATE KEY":

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -81,8 +81,6 @@ func (k *KeyHierarchy) GetKeyBackend(e efivar.Efivar) KeyBackend {
 		return k.KEK
 	case efivar.Db:
 		return k.Db
-		// case efivar.Dbx:
-		// 	return k.Dbx
 	default:
 		panic("invalid key hierarchy")
 	}
@@ -200,6 +198,8 @@ func createKey(state *config.State, backend string, hier hierarchy.Hierarchy, de
 		return NewFileKey(hier, desc)
 	case "tpm":
 		return NewTPMKey(state.TPM, desc)
+	case "yubikey":
+		return NewYubikeyKey(state.YubikeySigKeys, desc)
 	default:
 		return NewFileKey(hier, desc)
 	}
@@ -255,6 +255,8 @@ func readKey(state *config.State, keydir string, kc *config.KeyConfig, hier hier
 		return FileKeyFromBytes(keyb, pemb)
 	case TPMBackend:
 		return TPMKeyFromBytes(state.TPM, keyb, pemb)
+	case YubikeyBackend:
+		return YubikeyFromBytes(state.YubikeySigKeys, keyb, pemb)
 	default:
 		return nil, fmt.Errorf("unknown key")
 	}
@@ -302,6 +304,8 @@ func GetBackendType(b []byte) (BackendType, error) {
 		return FileBackend, nil
 	case "TSS2 PRIVATE KEY":
 		return TPMBackend, nil
+	case "PUBLIC KEY":
+		return YubikeyBackend, nil
 	default:
 		return "", fmt.Errorf("unknown file type: %s", block.Type)
 	}
@@ -322,6 +326,8 @@ func InitBackendFromKeys(state *config.State, priv, pem []byte, hier hierarchy.H
 		return FileKeyFromBytes(priv, pem)
 	case "tpm":
 		return TPMKeyFromBytes(state.TPM, priv, pem)
+	case "yubikey":
+		return YubikeyFromBytes(state.YubikeySigKeys, priv, pem)
 	default:
 		return nil, fmt.Errorf("unknown key backend: %s", t)
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -201,7 +201,7 @@ func createKey(state *config.State, backend string, hier hierarchy.Hierarchy, de
 	case "tpm":
 		return NewTPMKey(state.TPM, desc)
 	case "yubikey":
-		return NewYubikeyKey(state.YubikeySigKeys, desc)
+		return NewYubikeyKey(state.YubikeySigKeys, hier, desc)
 	default:
 		return NewFileKey(hier, desc)
 	}

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -2,43 +2,33 @@ package backend
 
 import (
 	"fmt"
-	"github.com/foxboron/sbctl/hierarchy"
 	"log"
 	"testing"
 
 	"github.com/foxboron/sbctl/config"
+	"github.com/foxboron/sbctl/hierarchy"
 	"github.com/spf13/afero"
 )
 
 func TestCreateKeys(t *testing.T) {
-	t.Logf("Testing create keys\n")
 	c := &config.Config{
 		Keydir: t.TempDir(),
 		Keys: &config.Keys{
 			PK: &config.KeyConfig{
-				Type: "yubikey",
+				Type: "file",
 			},
-			KEK: &config.KeyConfig{
-				Type: "yubikey",
-			},
-			Db: &config.KeyConfig{
-				Type: "yubikey",
-			},
+			KEK: &config.KeyConfig{},
+			Db:  &config.KeyConfig{},
 		},
 	}
 	state := &config.State{
-		Fs: afero.NewOsFs(),
-		YubikeySigKeys: &config.YubiConfig{
-			Pub:  nil,
-			Priv: nil,
-		},
+		Fs:     afero.NewOsFs(),
 		Config: c,
 	}
 	hier, err := CreateKeys(state)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
-	t.Logf("Created keys: %v\n", hier)
 
 	err = hier.SaveKeys(afero.NewOsFs(), c.Keydir)
 	if err != nil {
@@ -49,7 +39,5 @@ func TestCreateKeys(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	signer := key.Signer()
-	fmt.Printf("%v\n", signer)
 	fmt.Println(key.Certificate().Subject.CommonName)
 }

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -2,33 +2,43 @@ package backend
 
 import (
 	"fmt"
+	"github.com/foxboron/sbctl/hierarchy"
 	"log"
 	"testing"
 
 	"github.com/foxboron/sbctl/config"
-	"github.com/foxboron/sbctl/hierarchy"
 	"github.com/spf13/afero"
 )
 
 func TestCreateKeys(t *testing.T) {
+	t.Logf("Testing create keys\n")
 	c := &config.Config{
 		Keydir: t.TempDir(),
 		Keys: &config.Keys{
 			PK: &config.KeyConfig{
-				Type: "file",
+				Type: "yubikey",
 			},
-			KEK: &config.KeyConfig{},
-			Db:  &config.KeyConfig{},
+			KEK: &config.KeyConfig{
+				Type: "yubikey",
+			},
+			Db: &config.KeyConfig{
+				Type: "yubikey",
+			},
 		},
 	}
 	state := &config.State{
-		Fs:     afero.NewOsFs(),
+		Fs: afero.NewOsFs(),
+		YubikeySigKeys: &config.YubiConfig{
+			Pub:  nil,
+			Priv: nil,
+		},
 		Config: c,
 	}
 	hier, err := CreateKeys(state)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+	t.Logf("Created keys: %v\n", hier)
 
 	err = hier.SaveKeys(afero.NewOsFs(), c.Keydir)
 	if err != nil {
@@ -39,5 +49,7 @@ func TestCreateKeys(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	signer := key.Signer()
+	fmt.Printf("%v\n", signer)
 	fmt.Println(key.Certificate().Subject.CommonName)
 }

--- a/backend/yubikey.go
+++ b/backend/yubikey.go
@@ -15,13 +15,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tomis007/piv-go/v2/piv"
+	"github.com/go-piv/piv-go/v2/piv"
 )
 
 type Yubikey struct {
 	keytype BackendType
 	cert    *x509.Certificate
-	privkey *piv.KeyRSA
+	privkey crypto.Signer
 }
 
 func NewYubikeyKey(conf *config.YubiConfig, desc string) (*Yubikey, error) {
@@ -117,7 +117,7 @@ func NewYubikeyKey(conf *config.YubiConfig, desc string) (*Yubikey, error) {
 	return &Yubikey{
 		keytype: YubikeyBackend,
 		cert:    cert,
-		privkey: priv.(*piv.KeyRSA),
+		privkey: priv.(crypto.Signer),
 	}, nil
 }
 
@@ -171,7 +171,7 @@ func YubikeyFromBytes(conf *config.YubiConfig, keyb, pemb []byte) (*Yubikey, err
 	return &Yubikey{
 		keytype: YubikeyBackend,
 		cert:    cert,
-		privkey: priv.(*piv.KeyRSA),
+		privkey: priv.(crypto.Signer),
 	}, nil
 }
 

--- a/backend/yubikey.go
+++ b/backend/yubikey.go
@@ -1,0 +1,206 @@
+package backend
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"github.com/foxboron/sbctl/config"
+	"github.com/foxboron/sbctl/logging"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/tomis007/piv-go/v2/piv"
+)
+
+type Yubikey struct {
+	keytype BackendType
+	cert    *x509.Certificate
+	privkey *piv.KeyRSA
+}
+
+func NewYubikeyKey(conf *config.YubiConfig, desc string) (*Yubikey, error) {
+	var pub crypto.PublicKey
+	var priv crypto.PrivateKey
+	if conf.Priv == nil && conf.Pub == nil {
+		// List all smartcards connected to the system.
+		cards, err := piv.Cards()
+		if err != nil {
+			return nil, err
+		}
+
+		// Find a YubiKey and open the reader.
+		var yk *piv.YubiKey
+		for _, card := range cards {
+			if strings.Contains(strings.ToLower(card), "yubikey") {
+				if yk, err = piv.Open(card); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if yk == nil {
+			return nil, fmt.Errorf("yubikey key not found")
+		}
+		conf.YK = yk
+
+		keyInfo, err := yk.KeyInfo(piv.SlotSignature)
+		if err != nil {
+			return nil, err
+		}
+		if keyInfo.PublicKey != nil {
+			if keyInfo.Algorithm == piv.AlgorithmRSA2048 {
+				logging.Println("RSA 2048 Key exists in Yubikey PIV Signature Slot, using the existing key")
+				pub = keyInfo.PublicKey
+			} else {
+				return nil, fmt.Errorf("non RSA2048 key already in the slot")
+			}
+		} else {
+			// Generate a private key on the YubiKey.
+			key := piv.Key{
+				Algorithm:   piv.AlgorithmRSA2048,
+				PINPolicy:   piv.PINPolicyAlways,
+				TouchPolicy: piv.TouchPolicyAlways,
+			}
+			logging.Println("Creating key... please press Yubikey")
+			pub, err = yk.GenerateKey(piv.DefaultManagementKey, piv.SlotSignature, key)
+			if err != nil {
+				return nil, err
+			}
+
+		}
+
+		// TODO prompt for PIN when it's not default
+		auth := piv.KeyAuth{PIN: piv.DefaultPIN}
+		priv, err = yk.PrivateKey(piv.SlotSignature, pub, auth)
+		if err != nil {
+			return nil, err
+		}
+
+		conf.Pub = pub
+		conf.Priv = priv
+	} else {
+		// Key already setup for sbctl
+		pub = conf.Pub
+		priv = conf.Priv
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+	c := x509.Certificate{
+		SerialNumber:       serialNumber,
+		PublicKeyAlgorithm: x509.RSA,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().AddDate(5, 0, 0),
+		Subject: pkix.Name{
+			Country:    []string{desc},
+			CommonName: desc,
+		},
+	}
+
+	logging.Println("Creating certificate, please press Yubikey")
+	derBytes, err := x509.CreateCertificate(rand.Reader, &c, &c, pub, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Yubikey{
+		keytype: YubikeyBackend,
+		cert:    cert,
+		privkey: priv.(*piv.KeyRSA),
+	}, nil
+}
+
+func YubikeyFromBytes(conf *config.YubiConfig, keyb, pemb []byte) (*Yubikey, error) {
+	block, _ := pem.Decode(keyb)
+	if block == nil {
+		return nil, fmt.Errorf("failed to parse pem block")
+	}
+	pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse key: %w", err)
+	}
+	if conf.YK == nil {
+		cards, err := piv.Cards()
+		if err != nil {
+			return nil, err
+		}
+
+		// Find a YubiKey and open the reader.
+		var yk *piv.YubiKey
+		for _, card := range cards {
+			if strings.Contains(strings.ToLower(card), "yubikey") {
+				if yk, err = piv.Open(card); err != nil {
+					return nil, err
+				}
+			}
+		}
+		if yk == nil {
+			return nil, fmt.Errorf("yubikey not found")
+		}
+		conf.YK = yk
+	}
+
+	// List all smartcards connected to the system.
+	// TODO prompt for PIN
+	auth := piv.KeyAuth{PIN: piv.DefaultPIN}
+	priv, err := conf.YK.PrivateKey(piv.SlotSignature, pub, auth)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ = pem.Decode(pemb)
+	if block == nil {
+		return nil, fmt.Errorf("no pem block")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cert: %w", err)
+	}
+	return &Yubikey{
+		keytype: YubikeyBackend,
+		cert:    cert,
+		privkey: priv.(*piv.KeyRSA),
+	}, nil
+}
+
+func (f *Yubikey) Type() BackendType              { return f.keytype }
+func (f *Yubikey) Certificate() *x509.Certificate { return f.cert }
+
+func (f *Yubikey) Signer() crypto.Signer {
+	logging.Println("Signing operation: please press your Yubikey for confirmation\n")
+	return f.privkey
+}
+func (f *Yubikey) Description() string { return f.Certificate().Subject.SerialNumber }
+
+// save YubiKey Public Key Bytes as .PEM
+func (f *Yubikey) PrivateKeyBytes() []byte {
+	publicKeyBytes := x509.MarshalPKCS1PublicKey(f.privkey.Public().(*rsa.PublicKey))
+	if publicKeyBytes == nil {
+		panic("not a valid public key")
+	}
+	b := new(bytes.Buffer)
+	if err := pem.Encode(b, &pem.Block{Type: "PUBLIC KEY", Bytes: publicKeyBytes}); err != nil {
+		panic("failed producing PEM encoded certificate")
+	}
+	return b.Bytes()
+}
+
+func (f *Yubikey) CertificateBytes() []byte {
+	b := new(bytes.Buffer)
+	if err := pem.Encode(b, &pem.Block{Type: "CERTIFICATE", Bytes: f.cert.Raw}); err != nil {
+		panic("failed producing PEM encoded certificate")
+	}
+	return b.Bytes()
+}

--- a/backend/yubikey.go
+++ b/backend/yubikey.go
@@ -57,6 +57,7 @@ func PromptYubikeyPin() (string, error) {
 	prompt := promptui.Prompt{
 		Label:    "Yubikey PIV PIN: ",
 		Validate: validate,
+		Mask:     42, // '*'
 	}
 
 	result, err := prompt.Run()

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -15,10 +15,12 @@ import (
 )
 
 var (
-	exportPath                       string
-	databasePath                     string
-	Keytype                          string
-	PKKeytype, KEKKeytype, DbKeytype string
+	exportPath   string
+	databasePath string
+	Keytype      string
+	KEKKeytype   string
+	DbKeytype    string
+	PKKeytype    string
 )
 
 var createKeysCmd = &cobra.Command{
@@ -56,7 +58,7 @@ func RunCreateKeys(state *config.State) error {
 	}
 
 	// Should be own flag type
-	if Keytype != "" && (Keytype == "file" || Keytype == "tpm") {
+	if Keytype != "" && (Keytype == "file" || Keytype == "tpm" || Keytype == "yubikey") {
 		state.Config.Keys.PK.Type = Keytype
 		state.Config.Keys.KEK.Type = Keytype
 		state.Config.Keys.Db.Type = Keytype
@@ -105,7 +107,7 @@ func createKeysCmdFlags(cmd *cobra.Command) {
 	f.StringVarP(&Keytype, "keytype", "", "", "key type for all keys")
 	f.StringVarP(&PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
 	f.StringVarP(&KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
-	f.StringVarP(&DbKeytype, "db-keytype", "", "", "db key type (defualt: file)")
+	f.StringVarP(&DbKeytype, "db-keytype", "", "", "db key type (default: file)")
 }
 
 func init() {

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -74,15 +74,12 @@ func RunCreateKeys(state *config.State) error {
 		}
 	}
 
-	logging.Println("trying to create GUID:\n")
-	logging.Println(state.Config.GUID)
 	uuid, err := sbctl.CreateGUID(state.Fs, state.Config.GUID)
 	if err != nil {
 		return err
 	}
 	logging.Print("Created Owner UUID %s\n", uuid)
 	if !sbctl.CheckIfKeysInitialized(state.Fs, state.Config.Keydir) {
-		logging.Println("Creating secure boot keys...")
 
 		hier, err := backend.CreateKeys(state)
 		if err != nil {

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -35,7 +35,7 @@ var createKeysCmd = &cobra.Command{
 func RunCreateKeys(state *config.State) error {
 	if state.Config.Landlock {
 		lsm.RestrictAdditionalPaths(
-			landlock.RWDirs(filepath.Dir(filepath.Dir(filepath.Clean(state.Config.Keydir)))),
+			landlock.RWDirs(filepath.Dir(filepath.Clean(state.Config.Keydir))),
 		)
 		if err := lsm.Restrict(); err != nil {
 			return err
@@ -74,13 +74,15 @@ func RunCreateKeys(state *config.State) error {
 		}
 	}
 
+	logging.Println("trying to create GUID:\n")
+	logging.Println(state.Config.GUID)
 	uuid, err := sbctl.CreateGUID(state.Fs, state.Config.GUID)
 	if err != nil {
 		return err
 	}
 	logging.Print("Created Owner UUID %s\n", uuid)
 	if !sbctl.CheckIfKeysInitialized(state.Fs, state.Config.Keydir) {
-		logging.Print("Creating secure boot keys...")
+		logging.Println("Creating secure boot keys...")
 
 		hier, err := backend.CreateKeys(state)
 		if err != nil {

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -15,12 +15,13 @@ import (
 )
 
 var (
-	exportPath   string
-	databasePath string
-	Keytype      string
-	KEKKeytype   string
-	DbKeytype    string
-	PKKeytype    string
+	exportPath       string
+	databasePath     string
+	Keytype          string
+	KEKKeytype       string
+	DbKeytype        string
+	PKKeytype        string
+	OverwriteYubikey bool
 )
 
 var createKeysCmd = &cobra.Command{
@@ -48,6 +49,11 @@ func RunCreateKeys(state *config.State) error {
 
 	if databasePath != "" {
 		state.Config.GUID = databasePath
+	}
+
+	if OverwriteYubikey {
+		logging.Warn("Overwriting Yubikey option enabled")
+		state.YubikeySigKeys.Overwrite = true
 	}
 
 	if err := sbctl.CreateDirectory(state.Fs, state.Config.Keydir); err != nil {
@@ -101,6 +107,7 @@ func RunCreateKeys(state *config.State) error {
 
 func createKeysCmdFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
+	f.BoolVar(&OverwriteYubikey, "overwrite", false, "overwrite existing key if it exists in the Yubikey Signature slot")
 	f.StringVarP(&exportPath, "export", "e", "", "export file path")
 	f.StringVarP(&databasePath, "database-path", "d", "", "location to create GUID file")
 	f.StringVarP(&Keytype, "keytype", "", "", "key type for all keys")

--- a/cmd/sbctl/main.go
+++ b/cmd/sbctl/main.go
@@ -139,7 +139,6 @@ func main() {
 				if err != nil {
 					log.Fatal(err)
 				}
-				logging.Println("Loading config: /etc/sbctl/sbctl.conf")
 				conf, err = config.NewConfig(state.Fs, b)
 				if err != nil {
 					log.Fatal(err)

--- a/cmd/sbctl/main.go
+++ b/cmd/sbctl/main.go
@@ -114,7 +114,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			conf, err = config.NewConfig(b)
+			conf, err = config.NewConfig(state.Fs, b)
 			if err != nil {
 				return err
 			}
@@ -140,7 +140,7 @@ func main() {
 					log.Fatal(err)
 				}
 				logging.Println("Loading config: /etc/sbctl/sbctl.conf")
-				conf, err = config.NewConfig(b)
+				conf, err = config.NewConfig(state.Fs, b)
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/cmd/sbctl/main.go
+++ b/cmd/sbctl/main.go
@@ -96,7 +96,8 @@ func main() {
 	// We need to set this after we have parsed stuff
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		state := &config.State{
-			Fs: fs,
+			Fs:             fs,
+			YubikeySigKeys: &config.YubiConfig{},
 			TPM: func() transport.TPMCloser {
 				return rwc
 			},

--- a/cmd/sbctl/main.go
+++ b/cmd/sbctl/main.go
@@ -139,6 +139,7 @@ func main() {
 				if err != nil {
 					log.Fatal(err)
 				}
+				logging.Println("Loading config: /etc/sbctl/sbctl.conf")
 				conf, err = config.NewConfig(b)
 				if err != nil {
 					log.Fatal(err)

--- a/cmd/sbctl/setup.go
+++ b/cmd/sbctl/setup.go
@@ -45,7 +45,7 @@ func PrintConfig(state *config.State) error {
 		if err != nil {
 			return err
 		}
-		state.Config, err = config.NewConfig(b)
+		state.Config, err = config.NewConfig(state.Fs, b)
 		if err != nil {
 			return err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -167,6 +167,8 @@ func NewConfig(fs afero.Fs, b []byte) (*Config, error) {
 
 type YubiConfig struct {
 	PubKeyInfo *piv.KeyInfo
+	YK         *piv.YubiKey
+	Overwrite  bool
 }
 
 // Key creation is going to require different callbacks to we abstract them away

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"encoding/json"
 	"errors"
-	"github.com/tomis007/piv-go/v2/piv"
 	"os"
 	"path"
 	"strings"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/foxboron/go-uefi/efi/util"
 	"github.com/foxboron/go-uefi/efivarfs"
+	"github.com/go-piv/piv-go/v2/piv"
 	"github.com/google/go-tpm/tpm2/transport"
 	"github.com/google/uuid"
 	"github.com/spf13/afero"

--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,6 @@ func NewConfig(fs afero.Fs, b []byte) (*Config, error) {
 
 type YubiConfig struct {
 	PubKeyInfo *piv.KeyInfo
-	YK         *piv.YubiKey
 	Overwrite  bool
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"crypto"
 	"encoding/json"
 	"errors"
+	"github.com/tomis007/piv-go/v2/piv"
 	"os"
 	"path"
 	"strings"
@@ -104,7 +106,7 @@ func MkConfig(dir string) *Config {
 }
 
 func DefaultConfig() *Config {
-	return MkConfig("/var/lib/sbctl")
+	return MkConfig("/var/lib/sbctl/yubitest2")
 }
 
 func OldConfig(dir string) *Config {
@@ -133,12 +135,19 @@ func NewConfig(b []byte) (*Config, error) {
 	return conf, nil
 }
 
+type YubiConfig struct {
+	Pub  crypto.PublicKey
+	Priv crypto.PrivateKey
+	YK   *piv.YubiKey
+}
+
 // Key creation is going to require differen callbacks to we abstract them away
 type State struct {
-	Fs       afero.Fs
-	TPM      func() transport.TPMCloser
-	Config   *Config
-	Efivarfs *efivarfs.Efivarfs
+	Fs             afero.Fs
+	TPM            func() transport.TPMCloser
+	Config         *Config
+	YubikeySigKeys *YubiConfig
+	Efivarfs       *efivarfs.Efivarfs
 }
 
 func (s *State) IsInstalled() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,6 @@ func NewConfig(fs afero.Fs, b []byte) (*Config, error) {
 
 type YubiConfig struct {
 	PubKeyInfo *piv.KeyInfo
-	YK         *piv.YubiKey
 }
 
 // Key creation is going to require different callbacks to we abstract them away

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/onsi/gomega v1.7.1
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
+	github.com/tomis007/piv-go/v2 v2.0.0-20241222201455-731899948d7d
 	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848
 	golang.org/x/sys v0.22.0
 )

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/hugelgupf/vmtest v0.0.0-20240110072021-f6f07acb7aa1
 	github.com/landlock-lsm/go-landlock v0.0.0-20240715193425-db0c8d6f1dff
+	github.com/manifoldco/promptui v0.9.0
 	github.com/onsi/gomega v1.7.1
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
@@ -24,6 +25,7 @@ require (
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/creack/pty v1.1.21 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/certificate-transparency-go v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20240725205618-b7c5a84edf9d
 	github.com/foxboron/go-uefi v0.0.0-20241017190036-fab4fdf2f2f3
+	github.com/go-piv/piv-go/v2 v2.3.0
 	github.com/goccy/go-yaml v1.11.3
 	github.com/google/go-attestation v0.5.1
 	github.com/google/go-tpm v0.9.1
@@ -17,7 +18,6 @@ require (
 	github.com/onsi/gomega v1.7.1
 	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
-	github.com/tomis007/piv-go/v2 v2.0.0-20241222201455-731899948d7d
 	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848
 	golang.org/x/sys v0.22.0
 )

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,11 @@ github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -524,6 +527,8 @@ github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0U
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-piv/piv-go/v2 v2.3.0 h1:kKkrYlgLQTMPA6BiSL25A7/x4CEh2YCG7rtb/aTkx+g=
+github.com/go-piv/piv-go/v2 v2.3.0/go.mod h1:ShZi74nnrWNQEdWzRUd/3cSig3uNOcEZp+EWl0oewnI=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
@@ -748,8 +750,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
-github.com/tomis007/piv-go/v2 v2.0.0-20241222201455-731899948d7d h1:GOng4EK7xBL3jc8blueLNFiz/dqmMstg3JWrnNgMJSY=
-github.com/tomis007/piv-go/v2 v2.0.0-20241222201455-731899948d7d/go.mod h1:tvpi3/AowxtaslPQqA7CauGczZukyetegGv2jVaciFQ=
 github.com/u-root/gobusybox/src v0.0.0-20231224233253-2944a440b6b6 h1:AQX6C886dZqnOrXtbP0U59melqbb1+YnCfRYRfr4M3M=
 github.com/u-root/gobusybox/src v0.0.0-20231224233253-2944a440b6b6/go.mod h1:Zj4Tt22fJVn/nz/y6Ergm1SahR9dio1Zm/D2/S0TmXM=
 github.com/u-root/u-root v0.11.1-0.20230807200058-f87ad7ccb594 h1:1AIJqOtdEufYfGb3eRpdaqWONzBOpAwrg1fehbWg+Mg=

--- a/go.sum
+++ b/go.sum
@@ -748,6 +748,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
+github.com/tomis007/piv-go/v2 v2.0.0-20241222201455-731899948d7d h1:GOng4EK7xBL3jc8blueLNFiz/dqmMstg3JWrnNgMJSY=
+github.com/tomis007/piv-go/v2 v2.0.0-20241222201455-731899948d7d/go.mod h1:tvpi3/AowxtaslPQqA7CauGczZukyetegGv2jVaciFQ=
 github.com/u-root/gobusybox/src v0.0.0-20231224233253-2944a440b6b6 h1:AQX6C886dZqnOrXtbP0U59melqbb1+YnCfRYRfr4M3M=
 github.com/u-root/gobusybox/src v0.0.0-20231224233253-2944a440b6b6/go.mod h1:Zj4Tt22fJVn/nz/y6Ergm1SahR9dio1Zm/D2/S0TmXM=
 github.com/u-root/u-root v0.11.1-0.20230807200058-f87ad7ccb594 h1:1AIJqOtdEufYfGb3eRpdaqWONzBOpAwrg1fehbWg+Mg=

--- a/lsm/lsm.go
+++ b/lsm/lsm.go
@@ -29,7 +29,7 @@ func LandlockRulesFromConfig(conf *config.Config) {
 		landlock.RWDirs(
 			filepath.Dir(conf.Keydir),
 			// It seems to me that RWFiles should work on efivars, but it doesn't.
-			// TODO: Lock this down to induvidual files?
+			// TODO: Lock this down to individual files?
 			"/sys/firmware/efi/efivars/",
 		).IgnoreIfMissing(),
 		landlock.ROFiles(
@@ -41,6 +41,8 @@ func LandlockRulesFromConfig(conf *config.Config) {
 			conf.GUID,
 			conf.FilesDb,
 			conf.BundlesDb,
+			//TODO will this be different for others for yubikeys?
+			"/usr/lib/libpcsclite_real.so.1",
 			// Enable the TPM devices by default if they exist
 			"/dev/tpm0", "/dev/tpmrm0",
 		).IgnoreIfMissing(),

--- a/lsm/lsm.go
+++ b/lsm/lsm.go
@@ -25,17 +25,21 @@ func LandlockRulesFromConfig(conf *config.Config) {
 	rules = append(rules,
 		landlock.RODirs(
 			"/sys/devices/virtual/dmi/id/",
+			"/usr/lib",
 		).IgnoreIfMissing(),
 		landlock.RWDirs(
 			filepath.Dir(conf.Keydir),
 			// It seems to me that RWFiles should work on efivars, but it doesn't.
 			// TODO: Lock this down to individual files?
 			"/sys/firmware/efi/efivars/",
+			"/run/systemd/ask-password/",
 		).IgnoreIfMissing(),
 		landlock.ROFiles(
 			"/sys/kernel/security/tpm0/binary_bios_measurements",
 			// Go timezone reads /etc/localtime
 			"/etc/localtime",
+			"/proc/sys/kernel/cap_last_cap",
+			"/usr/bin/systemd-ask-password",
 		).IgnoreIfMissing(),
 		landlock.RWFiles(
 			conf.GUID,
@@ -43,6 +47,7 @@ func LandlockRulesFromConfig(conf *config.Config) {
 			conf.BundlesDb,
 			//TODO will this be different for others for yubikeys?
 			"/usr/lib/libpcsclite_real.so.1",
+			"/dev/null",
 			// Enable the TPM devices by default if they exist
 			"/dev/tpm0", "/dev/tpmrm0",
 		).IgnoreIfMissing(),

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -1,0 +1,21 @@
+package prompt
+
+import (
+	"github.com/manifoldco/promptui"
+)
+
+func SBCTLPrompt(validate func(string) error, label string, mask *rune) (string, error) {
+	prompt := promptui.Prompt{
+		Label:    label,
+		Validate: validate,
+	}
+	if mask != nil {
+		prompt.Mask = *mask
+	}
+
+	result, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -15,12 +15,13 @@ func SBCTLPrompt(validate func(string) error, label string, mask *rune) (string,
 	} else {
 		logging.Warn("not running in a TTY -- prompting with systemd-ask-password")
 		logging.Warn(fmt.Sprintf("(PROMPT) %s", label))
-		logging.Print("Run \"systemd-tty-ask-password-agent --query\" in another terminal\n")
+		logging.Warn("Run \"systemd-tty-ask-password-agent --query\" in another terminal\n")
 		cmd := exec.Command("/usr/bin/systemd-ask-password",
 			"--emoji=no",
 			"--timeout=0",
 			"-n",
 			"--echo=masked",
+			"sbctl Yubikey PIN",
 		)
 		output, err := cmd.Output()
 		if err != nil {

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -1,10 +1,40 @@
 package prompt
 
 import (
+	"fmt"
+	"github.com/foxboron/sbctl/logging"
 	"github.com/manifoldco/promptui"
+	"golang.org/x/sys/unix"
+	"os"
+	"os/exec"
 )
 
 func SBCTLPrompt(validate func(string) error, label string, mask *rune) (string, error) {
+	if IsTerminal(os.Stdout.Fd()) {
+		return TTYPrompt(validate, label, mask)
+	} else {
+		logging.Warn("not running in a TTY -- prompting with systemd-ask-password")
+		logging.Warn(fmt.Sprintf("(PROMPT) %s", label))
+		logging.Print("Run \"systemd-tty-ask-password-agent --query\" in another terminal\n")
+		cmd := exec.Command("/usr/bin/systemd-ask-password",
+			"--emoji=no",
+			"--timeout=0",
+			"-n",
+			"--echo=masked",
+		)
+		output, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		if err = validate(string(output)); err != nil {
+			return "", err
+		} else {
+			return string(output), nil
+		}
+	}
+}
+
+func TTYPrompt(validate func(string) error, label string, mask *rune) (string, error) {
 	prompt := promptui.Prompt{
 		Label:    label,
 		Validate: validate,
@@ -18,4 +48,10 @@ func SBCTLPrompt(validate func(string) error, label string, mask *rune) (string,
 		return "", err
 	}
 	return result, nil
+}
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	return err == nil
 }


### PR DESCRIPTION
Hey! Super cool project. I wanted to add yubikey support with its `piv` feature. Here's my initial PR for that. It's a work in progress -- please do not merge the code is still hacky, but I made the PR to get your take on my implementation so far. A few notes:

* the `go-piv/piv-go` project has a bug where it doesn't actually export a few of the key types because they have lowercase names. I submitted https://github.com/go-piv/piv-go/pull/164 to fix that
* I'm storing `priv` in the config passed to the yubikey type but I am not sure if that's needed or if it's better to just prompt every time instead
* I put one private key in the 9C slot (https://docs.yubico.com/yesdk/users-manual/application-piv/slots.html) and used that for all 3 of the required keys that are generated for secure boot. Is there a better way to do this? Maybe 3 different ones in the other slots? My current implementation works as it requires a pin for every signature with the key https://developers.yubico.com/PIV/Introduction/Certificate_slots.html
* I sort of had to hack it together because it doesn't look like the config file is finished yet. I could fix that up too to make it easier to use the yubikey piv signing 
* I'm not storing the private key on disk, instead storing the public key and using that to request the private key from the yubikey when needed. I think that makes the most sense

Thanks!