### PR TITLE
fix: print an error on setup without args

### DIFF
--- a/cmd/sbctl/setup.go
+++ b/cmd/sbctl/setup.go
@@ -237,6 +237,8 @@ func setupCmdFlags(cmd *cobra.Command) {
 	f.BoolVarP(&setupCmdOptions.PrintState, "print-state", "", false, "print the state of sbctl")
 	f.BoolVarP(&setupCmdOptions.Migrate, "migrate", "", false, "migrate the sbctl installation")
 	f.BoolVarP(&setupCmdOptions.Setup, "setup", "", false, "setup the sbctl installation")
+	cmd.MarkFlagsOneRequired("print-config", "print-state", "migrate", "setup")
+	cmd.MarkFlagsMutuallyExclusive("print-config", "print-state", "migrate", "setup")
 }
 
 func init() {


### PR DESCRIPTION
`sbctl setup` exits with status code 0 and doesn't print anything. Because one argument is required (`--migrate`, `--print-config`, `--print-state` or `--setup`), `sbctl setup` without other options should be an error.