### PR TITLE
list-enrolled-keys: Return subject instead of issuer of enrolled certificates

### DIFF
--- a/cmd/sbctl/list-enrolled-keys.go
+++ b/cmd/sbctl/list-enrolled-keys.go
@@ -89,7 +89,7 @@ func printCertsPlainText(certList map[string][]*x509.Certificate) {
 	for db, certs := range certList {
 		fmt.Printf("%s:\n", db)
 		for _, c := range certs {
-			fmt.Printf("  %s\n", c.Issuer.CommonName)
+			fmt.Printf("  %s\n", c.Subject.CommonName)
 		}
 	}
 }


### PR DESCRIPTION
Right now `sbctl list-enrolled-keys` prints the issuer/CA of the installed certificates

```
PK:
  HP Inc. PK 2016 CA
KEK:
  HP Inc. KEK 2016 CA
  Microsoft Corporation Third Party Marketplace Root
DB:
  Microsoft Root Certificate Authority 2010
  HP Inc. DB Key 2016 CA
  Microsoft Corporation Third Party Marketplace Root
```

This makes it hard to identify the exact certificate, that has been installed. E.g. above, the MS KEK entry shows the same name as the DB entry, as they have been signed by the same CA. Yet the two certificates are different in nature.

sbctl should rather return the subject of the certificates instead
```
PK:
  HP UEFI Secure Boot PK 2017
KEK:
  HP UEFI Secure Boot KEK 2017
  Microsoft Corporation KEK CA 2011
DB:
  Microsoft Windows Production PCA 2011
  HP UEFI Secure Boot DB 2017
  Microsoft Corporation UEFI CA 2011
```