### PR TITLE
fix(kernel-install): support grub layout

### DIFF
--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -4,10 +4,7 @@
 COMMAND="$1"
 KERNEL_VERSION="$2"
 ENTRY_DIR_ABS="$3"
-# shellcheck disable=SC2034  # Unused variables left for readability
 KERNEL_IMAGE="$4"
-
-IMAGE_FILE="$ENTRY_DIR_ABS/linux"
 
 if [ "$KERNEL_INSTALL_LAYOUT" = "uki" ]; then
 	UKI_DIR="$KERNEL_INSTALL_BOOT_ROOT/EFI/Linux"
@@ -23,6 +20,10 @@ if [ "$KERNEL_INSTALL_LAYOUT" = "uki" ]; then
 	else
 		IMAGE_FILE="$UKI_DIR/$KERNEL_INSTALL_ENTRY_TOKEN-$KERNEL_VERSION.efi"
 	fi
+elif [ "$KERNEL_INSTALL_LAYOUT" = "grub" ]; then
+	IMAGE_FILE="$KERNEL_IMAGE"
+else
+	IMAGE_FILE="$ENTRY_DIR_ABS/linux"
 fi
 
 case "$COMMAND" in

--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -21,11 +21,13 @@ if [ "$KERNEL_INSTALL_LAYOUT" = "uki" ]; then
 	else
 		IMAGE_FILE="$UKI_DIR/$KERNEL_INSTALL_ENTRY_TOKEN-$KERNEL_VERSION.efi"
 	fi
-# Gentoo uses grub layout where kernel-install doesn't copy the kernel
-# to the entry directory but installs it to /boot/ directly.
+# layout=grub is a Gentoo convention (not upstream systemd). Gentoo's
+# 90-compat.install copies the kernel to /boot/kernel-<version>, so we
+# must sign the installed copy, not the source $KERNEL_IMAGE (which may
+# point to the build tree, e.g. /usr/src/linux-.../arch/x86/boot/bzImage).
 # See: https://github.com/Foxboron/sbctl/issues/491
 elif [ "$KERNEL_INSTALL_LAYOUT" = "grub" ]; then
-	IMAGE_FILE="$KERNEL_IMAGE"
+	IMAGE_FILE="/boot/kernel-${KERNEL_VERSION}"
 else
 	IMAGE_FILE="$ENTRY_DIR_ABS/linux"
 fi

--- a/contrib/kernel-install/91-sbctl.install
+++ b/contrib/kernel-install/91-sbctl.install
@@ -4,6 +4,7 @@
 COMMAND="$1"
 KERNEL_VERSION="$2"
 ENTRY_DIR_ABS="$3"
+# shellcheck disable=SC2034  # Unused variables left for readability
 KERNEL_IMAGE="$4"
 
 if [ "$KERNEL_INSTALL_LAYOUT" = "uki" ]; then
@@ -20,6 +21,9 @@ if [ "$KERNEL_INSTALL_LAYOUT" = "uki" ]; then
 	else
 		IMAGE_FILE="$UKI_DIR/$KERNEL_INSTALL_ENTRY_TOKEN-$KERNEL_VERSION.efi"
 	fi
+# Gentoo uses grub layout where kernel-install doesn't copy the kernel
+# to the entry directory but installs it to /boot/ directly.
+# See: https://github.com/Foxboron/sbctl/issues/491
 elif [ "$KERNEL_INSTALL_LAYOUT" = "grub" ]; then
 	IMAGE_FILE="$KERNEL_IMAGE"
 else


### PR DESCRIPTION
Hi, I have added an elif branch for `layout=grub` that uses `$KERNEL_IMAGE`, which points to the actual kernel image. Tested it on Gentoo and the kernel now emerges successfully.

Fixes #491