### PR TITLE
fix: Restrict access to imported key material

### DIFF
--- a/cmd/sbctl/import-keys.go
+++ b/cmd/sbctl/import-keys.go
@@ -39,13 +39,17 @@ var (
 
 func Import(vfs afero.Fs, src, dst string) error {
 	logging.Print("Importing %s...", src)
-	if err := os.MkdirAll(filepath.Dir(dst), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
 		logging.NotOk("")
 		return fmt.Errorf("could not create directory for %q: %w", dst, err)
 	}
 	if err := sbctl.CopyFile(vfs, src, dst); err != nil {
 		logging.NotOk("")
 		return fmt.Errorf("could not move %s: %w", src, err)
+	}
+	if err := vfs.Chmod(dst, 0o400); err != nil {
+		logging.NotOk("")
+		return fmt.Errorf("could not set file permissions %s: %w", dst, err)
 	}
 	logging.Ok("")
 	return nil


### PR DESCRIPTION
Without this change imported key-material is copied as-is, which could be extremely permissive. Since we know we are handling confidential key-material, let's restrict the access to the imported files.