### PR TITLE
Implement support for partial keys

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -76,21 +76,21 @@ func (k *KeyHierarchy) GetKeyBackend(e efivar.Efivar) (KeyBackend, error) {
 	switch e {
 	case efivar.PK:
 		if k.pk == nil {
-			if k.pk, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.PK, hierarchy.PK); err != nil {
+			if k.pk, err = k.ReadKey(hierarchy.PK); err != nil {
 				return nil, err
 			}
 		}
 		return k.pk, nil
 	case efivar.KEK:
 		if k.kek == nil {
-			if k.kek, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.KEK, hierarchy.KEK); err != nil {
+			if k.kek, err = k.ReadKey(hierarchy.KEK); err != nil {
 				return nil, err
 			}
 		}
 		return k.kek, nil
 	case efivar.Db:
 		if k.db == nil {
-			if k.db, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.Db, hierarchy.Db); err != nil {
+			if k.db, err = k.ReadKey(hierarchy.Db); err != nil {
 				return nil, err
 			}
 		}
@@ -210,6 +210,64 @@ func (k *KeyHierarchy) SaveKeys(fs afero.Fs, keydir string) error {
 	return nil
 }
 
+// ReadKey loads the given hierarchy from disk and returns its KeyBackend.
+func (k *KeyHierarchy) ReadKey(hier hierarchy.Hierarchy) (KeyBackend, error) {
+	path := filepath.Join(k.state.Config.Keydir, hier.String())
+	keyname := filepath.Join(path, fmt.Sprintf("%s.key", hier.String()))
+	certname := filepath.Join(path, fmt.Sprintf("%s.pem", hier.String()))
+
+	// Read privatekey
+	keyb, err := fs.ReadFile(k.state.Fs, keyname)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read certificate
+	pemb, err := fs.ReadFile(k.state.Fs, certname)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := GetBackendType(keyb)
+	if err != nil {
+		return nil, err
+	}
+
+	switch t {
+	case FileBackend:
+		return FileKeyFromBytes(keyb, pemb)
+	case TPMBackend:
+		return TPMKeyFromBytes(k.state.TPM, keyb, pemb)
+	case YubikeyBackend:
+		return YubikeyFromBytes(k.state.Yubikey, keyb, pemb)
+	default:
+		return nil, fmt.Errorf("unknown key")
+	}
+}
+
+// ReadKeys loads the entire hierarchy from disk and updates their KeyBackends.
+func (k *KeyHierarchy) ReadKeys() error {
+	var kb KeyBackend
+	var err error
+
+	if kb, err = k.ReadKey(hierarchy.PK); err != nil {
+		return err
+	}
+	k.UpdateKeyBackend(kb, hierarchy.PK)
+
+	if kb, err = k.ReadKey(hierarchy.KEK); err != nil {
+		return err
+	}
+	k.UpdateKeyBackend(kb, hierarchy.KEK)
+
+	if kb, err = k.ReadKey(hierarchy.Db); err != nil {
+		return err
+	}
+	k.UpdateKeyBackend(kb, hierarchy.Db)
+
+	return nil
+}
+
 func (k *KeyHierarchy) RotateKeyWithBackend(hier hierarchy.Hierarchy, backend BackendType) error {
 	var err error
 	switch hier {
@@ -285,53 +343,6 @@ func (k *KeyHierarchy) SignFile(hier hierarchy.Hierarchy, peBinary *authenticode
 		return nil, err
 	}
 	return peBinary.Bytes(), nil
-}
-
-func readKey(state *config.State, keydir string, kc *config.KeyConfig, hier hierarchy.Hierarchy) (KeyBackend, error) {
-	path := filepath.Join(keydir, hier.String())
-	keyname := filepath.Join(path, fmt.Sprintf("%s.key", hier.String()))
-	certname := filepath.Join(path, fmt.Sprintf("%s.pem", hier.String()))
-
-	// Read privatekey
-	keyb, err := fs.ReadFile(state.Fs, keyname)
-	if err != nil {
-		return nil, err
-	}
-
-	// Read certificate
-	pemb, err := fs.ReadFile(state.Fs, certname)
-	if err != nil {
-		return nil, err
-	}
-
-	t, err := GetBackendType(keyb)
-	if err != nil {
-		return nil, err
-	}
-
-	switch t {
-	case FileBackend:
-		return FileKeyFromBytes(keyb, pemb)
-	case TPMBackend:
-		return TPMKeyFromBytes(state.TPM, keyb, pemb)
-	case YubikeyBackend:
-		return YubikeyFromBytes(state.Yubikey, keyb, pemb)
-	default:
-		return nil, fmt.Errorf("unknown key")
-	}
-}
-
-func GetKeyBackend(state *config.State, k hierarchy.Hierarchy) (KeyBackend, error) {
-	c := state.Config
-	switch k {
-	case hierarchy.PK:
-		return readKey(state, c.Keydir, c.Keys.PK, k)
-	case hierarchy.KEK:
-		return readKey(state, c.Keydir, c.Keys.KEK, k)
-	case hierarchy.Db:
-		return readKey(state, c.Keydir, c.Keys.Db, k)
-	}
-	return nil, nil
 }
 
 func NewKeyHierarchy(state *config.State) *KeyHierarchy {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -46,21 +46,28 @@ type KeyHierarchy struct {
 }
 
 func (k *KeyHierarchy) GetConfig(keydir string) *config.Keys {
+	keyType := func(key interface{ Type() BackendType }) string {
+		if key == nil {
+			return string(FileBackend)
+		}
+		return string(key.Type())
+	}
+
 	return &config.Keys{
 		PK: &config.KeyConfig{
 			Privkey: filepath.Join(keydir, "PK/PK.key"),
 			Pubkey:  filepath.Join(keydir, "PK/PK.pem"),
-			Type:    string(k.pk.Type()),
+			Type:    keyType(k.pk),
 		},
 		KEK: &config.KeyConfig{
 			Privkey: filepath.Join(keydir, "KEK/KEK.key"),
 			Pubkey:  filepath.Join(keydir, "KEK/KEK.pem"),
-			Type:    string(k.kek.Type()),
+			Type:    keyType(k.kek),
 		},
 		Db: &config.KeyConfig{
 			Privkey: filepath.Join(keydir, "db/db.key"),
 			Pubkey:  filepath.Join(keydir, "db/db.pem"),
-			Type:    string(k.db.Type()),
+			Type:    keyType(k.db),
 		},
 	}
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -37,9 +37,9 @@ type KeyBackend interface {
 }
 
 type KeyHierarchy struct {
-	PK  KeyBackend
-	KEK KeyBackend
-	Db  KeyBackend
+	pk  KeyBackend
+	kek KeyBackend
+	db  KeyBackend
 	// We need the callbacks
 	state *config.State
 }
@@ -49,17 +49,17 @@ func (k *KeyHierarchy) GetConfig(keydir string) *config.Keys {
 		PK: &config.KeyConfig{
 			Privkey: filepath.Join(keydir, "PK/PK.key"),
 			Pubkey:  filepath.Join(keydir, "PK/PK.pem"),
-			Type:    string(k.PK.Type()),
+			Type:    string(k.pk.Type()),
 		},
 		KEK: &config.KeyConfig{
 			Privkey: filepath.Join(keydir, "KEK/KEK.key"),
 			Pubkey:  filepath.Join(keydir, "KEK/KEK.pem"),
-			Type:    string(k.KEK.Type()),
+			Type:    string(k.kek.Type()),
 		},
 		Db: &config.KeyConfig{
 			Privkey: filepath.Join(keydir, "db/db.key"),
 			Pubkey:  filepath.Join(keydir, "db/db.pem"),
-			Type:    string(k.Db.Type()),
+			Type:    string(k.db.Type()),
 		},
 	}
 }
@@ -75,28 +75,39 @@ func (k *KeyHierarchy) GetKeyBackend(e efivar.Efivar) (KeyBackend, error) {
 
 	switch e {
 	case efivar.PK:
-		if k.PK == nil {
-			if k.PK, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.PK, hierarchy.PK); err != nil {
+		if k.pk == nil {
+			if k.pk, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.PK, hierarchy.PK); err != nil {
 				return nil, err
 			}
 		}
-		return k.PK, nil
+		return k.pk, nil
 	case efivar.KEK:
-		if k.KEK == nil {
-			if k.KEK, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.KEK, hierarchy.KEK); err != nil {
+		if k.kek == nil {
+			if k.kek, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.KEK, hierarchy.KEK); err != nil {
 				return nil, err
 			}
 		}
-		return k.KEK, nil
+		return k.kek, nil
 	case efivar.Db:
-		if k.Db == nil {
-			if k.Db, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.Db, hierarchy.Db); err != nil {
+		if k.db == nil {
+			if k.db, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.Db, hierarchy.Db); err != nil {
 				return nil, err
 			}
 		}
-		return k.Db, nil
+		return k.db, nil
 	default:
 		panic("invalid key hierarchy")
+	}
+}
+
+func (k *KeyHierarchy) UpdateKeyBackend(kb KeyBackend, hier hierarchy.Hierarchy) {
+	switch hier {
+	case hierarchy.PK:
+		k.pk = kb
+	case hierarchy.KEK:
+		k.kek = kb
+	case hierarchy.Db:
+		k.db = kb
 	}
 }
 
@@ -143,11 +154,11 @@ func (k *KeyHierarchy) RotateKeyWithBackend(hier hierarchy.Hierarchy, backend Ba
 	var err error
 	switch hier {
 	case hierarchy.PK:
-		k.PK, err = createKey(k.state, string(backend), hier, k.PK.Description())
+		k.pk, err = createKey(k.state, string(backend), hier, k.pk.Description())
 	case hierarchy.KEK:
-		k.KEK, err = createKey(k.state, string(backend), hier, k.KEK.Description())
+		k.kek, err = createKey(k.state, string(backend), hier, k.kek.Description())
 	case hierarchy.Db:
-		k.Db, err = createKey(k.state, string(backend), hier, k.Db.Description())
+		k.db, err = createKey(k.state, string(backend), hier, k.db.Description())
 	}
 	return err
 }
@@ -237,17 +248,17 @@ func CreateKeys(state *config.State) (*KeyHierarchy, error) {
 	var err error
 
 	c := state.Config
-	hier.PK, err = createKey(state, c.Keys.PK.Type, hierarchy.PK, c.Keys.PK.Description)
+	hier.pk, err = createKey(state, c.Keys.PK.Type, hierarchy.PK, c.Keys.PK.Description)
 	if err != nil {
 		return nil, err
 	}
 
-	hier.KEK, err = createKey(state, c.Keys.KEK.Type, hierarchy.KEK, c.Keys.KEK.Description)
+	hier.kek, err = createKey(state, c.Keys.KEK.Type, hierarchy.KEK, c.Keys.KEK.Description)
 	if err != nil {
 		return nil, err
 	}
 
-	hier.Db, err = createKey(state, c.Keys.Db.Type, hierarchy.Db, c.Keys.Db.Description)
+	hier.db, err = createKey(state, c.Keys.Db.Type, hierarchy.Db, c.Keys.Db.Description)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -64,12 +64,6 @@ func (k *KeyHierarchy) GetConfig(keydir string) *config.Keys {
 	}
 }
 
-func NewKeyHierarchy(state *config.State) *KeyHierarchy {
-	return &KeyHierarchy{
-		state: state,
-	}
-}
-
 var (
 	ErrAlreadySigned = errors.New("already signed file")
 )
@@ -308,25 +302,10 @@ func GetKeyBackend(state *config.State, k hierarchy.Hierarchy) (KeyBackend, erro
 	return nil, nil
 }
 
-func GetKeyHierarchy(vfs afero.Fs, state *config.State) (*KeyHierarchy, error) {
-	db, err := GetKeyBackend(state, hierarchy.Db)
-	if err != nil {
-		return nil, err
-	}
-	kek, err := GetKeyBackend(state, hierarchy.KEK)
-	if err != nil {
-		return nil, err
-	}
-	pk, err := GetKeyBackend(state, hierarchy.PK)
-	if err != nil {
-		return nil, err
-	}
+func NewKeyHierarchy(state *config.State) *KeyHierarchy {
 	return &KeyHierarchy{
-		PK:    pk,
-		KEK:   kek,
-		Db:    db,
 		state: state,
-	}, nil
+	}
 }
 
 func GetBackendType(b []byte) (BackendType, error) {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/foxboron/sbctl/config"
 	"github.com/foxboron/sbctl/fs"
 	"github.com/foxboron/sbctl/hierarchy"
+	"github.com/foxboron/sbctl/logging"
 	"github.com/spf13/afero"
 )
 
@@ -131,6 +132,7 @@ func (k *KeyHierarchy) CreateKey(backend BackendType, hier hierarchy.Hierarchy, 
 		kb, err = NewYubikeyKey(k.state.Yubikey, hier)
 
 	default:
+		logging.Warn("backend '%s' unknown, falling back to '%s'", backend, FileBackend)
 		kb, err = NewFileKey(hier, desc)
 	}
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -166,6 +166,11 @@ func (k *KeyHierarchy) CreateKeys() error {
 	return nil
 }
 
+// TODO: fix this
+func (k *KeyHierarchy) ImportKeys(keydir string) error {
+	return fmt.Errorf("importing keys not implemented!")
+}
+
 func (k *KeyHierarchy) SaveKey(vfs afero.Fs, hier hierarchy.Hierarchy, keydir string) error {
 	writeFile := func(file string, b []byte) error {
 		if err := vfs.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
@@ -352,11 +357,6 @@ func GetBackendType(b []byte) (BackendType, error) {
 	default:
 		return "", fmt.Errorf("unknown file type: %s", block.Type)
 	}
-}
-
-// TODO: fix this
-func ImportKeys(keydir string) (*KeyHierarchy, error) {
-	return nil, nil
 }
 
 func InitBackendFromKeys(state *config.State, priv, pem []byte, hier hierarchy.Hierarchy) (KeyBackend, error) {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -74,14 +74,33 @@ var (
 	ErrAlreadySigned = errors.New("already signed file")
 )
 
-func (k *KeyHierarchy) GetKeyBackend(e efivar.Efivar) KeyBackend {
+// GetKeyBackend returns the currently loaded KeyBackend of the given efivar,
+// or attempts to load it from disk if none is currently loaded.
+func (k *KeyHierarchy) GetKeyBackend(e efivar.Efivar) (KeyBackend, error) {
+	var err error
+
 	switch e {
 	case efivar.PK:
-		return k.PK
+		if k.PK == nil {
+			if k.PK, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.PK, hierarchy.PK); err != nil {
+				return nil, err
+			}
+		}
+		return k.PK, nil
 	case efivar.KEK:
-		return k.KEK
+		if k.KEK == nil {
+			if k.KEK, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.KEK, hierarchy.KEK); err != nil {
+				return nil, err
+			}
+		}
+		return k.KEK, nil
 	case efivar.Db:
-		return k.Db
+		if k.Db == nil {
+			if k.Db, err = readKey(k.state, k.state.Config.Keydir, k.state.Config.Keys.Db, hierarchy.Db); err != nil {
+				return nil, err
+			}
+		}
+		return k.Db, nil
 	default:
 		panic("invalid key hierarchy")
 	}
@@ -97,14 +116,17 @@ func (k *KeyHierarchy) SaveKey(vfs afero.Fs, hier hierarchy.Hierarchy, keydir st
 		}
 		return nil
 	}
-	key := k.GetKeyBackend(hier.Efivar())
+	kb, err := k.GetKeyBackend(hier.Efivar())
+	if err != nil {
+		return err
+	}
 	path := filepath.Join(keydir, hier.String())
 	keyname := filepath.Join(path, fmt.Sprintf("%s.key", hier.String()))
 	certname := filepath.Join(path, fmt.Sprintf("%s.pem", hier.String()))
-	if err := writeFile(keyname, key.PrivateKeyBytes()); err != nil {
+	if err := writeFile(keyname, kb.PrivateKeyBytes()); err != nil {
 		return err
 	}
-	if err := writeFile(certname, key.CertificateBytes()); err != nil {
+	if err := writeFile(certname, kb.CertificateBytes()); err != nil {
 		return err
 	}
 	return nil
@@ -137,7 +159,11 @@ func (k *KeyHierarchy) RotateKeyWithBackend(hier hierarchy.Hierarchy, backend Ba
 }
 
 func (k *KeyHierarchy) RotateKey(hier hierarchy.Hierarchy) error {
-	return k.RotateKeyWithBackend(hier, k.GetKeyBackend(hier.Efivar()).Type())
+	kb, err := k.GetKeyBackend(hier.Efivar())
+	if err != nil {
+		return err
+	}
+	return k.RotateKeyWithBackend(hier, kb.Type())
 }
 
 func (k *KeyHierarchy) RotateKeys() error {
@@ -154,7 +180,10 @@ func (k *KeyHierarchy) RotateKeys() error {
 }
 
 func (k *KeyHierarchy) VerifyFile(hier hierarchy.Hierarchy, r io.ReaderAt) (bool, error) {
-	kk := k.GetKeyBackend(hier.Efivar())
+	kb, err := k.GetKeyBackend(hier.Efivar())
+	if err != nil {
+		return false, err
+	}
 
 	peBinary, err := authenticode.Parse(r)
 	if err != nil {
@@ -170,7 +199,7 @@ func (k *KeyHierarchy) VerifyFile(hier hierarchy.Hierarchy, r io.ReaderAt) (bool
 		return false, nil
 	}
 
-	ok, err := peBinary.Verify(kk.Certificate())
+	ok, err := peBinary.Verify(kb.Certificate())
 	if errors.Is(err, authenticode.ErrNoValidSignatures) {
 		return false, nil
 	} else if err != nil {
@@ -180,10 +209,13 @@ func (k *KeyHierarchy) VerifyFile(hier hierarchy.Hierarchy, r io.ReaderAt) (bool
 }
 
 func (k *KeyHierarchy) SignFile(hier hierarchy.Hierarchy, peBinary *authenticode.PECOFFBinary) ([]byte, error) {
-	kk := k.GetKeyBackend(hier.Efivar())
-	signer := kk.Signer()
+	kb, err := k.GetKeyBackend(hier.Efivar())
+	if err != nil {
+		return nil, err
+	}
+	signer := kb.Signer()
 
-	_, err := peBinary.Sign(signer, kk.Certificate())
+	_, err = peBinary.Sign(signer, kb.Certificate())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -111,6 +111,61 @@ func (k *KeyHierarchy) UpdateKeyBackend(kb KeyBackend, hier hierarchy.Hierarchy)
 	}
 }
 
+// CreateKey generates private and public parts of the given hierarchy and updates its KeyBackend.
+func (k *KeyHierarchy) CreateKey(backend BackendType, hier hierarchy.Hierarchy, desc string) error {
+	var kb KeyBackend
+	var err error
+
+	if desc == "" {
+		desc = hier.Description()
+	}
+
+	switch backend {
+	case FileBackend:
+		kb, err = NewFileKey(hier, desc)
+
+	case TPMBackend:
+		kb, err = NewTPMKey(k.state.TPM, desc)
+
+	case YubikeyBackend:
+		kb, err = NewYubikeyKey(k.state.Yubikey, hier)
+
+	default:
+		kb, err = NewFileKey(hier, desc)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	k.UpdateKeyBackend(kb, hier)
+
+	return nil
+}
+
+// CreateKeys generates private and public parts of the entire hierarchy and updates their KeyBackends.
+func (k *KeyHierarchy) CreateKeys() error {
+	var err error
+	c := k.state.Config
+
+	err = k.CreateKey(BackendType(c.Keys.PK.Type), hierarchy.PK, c.Keys.PK.Description)
+	if err != nil {
+		return err
+	}
+
+	err = k.CreateKey(BackendType(c.Keys.KEK.Type), hierarchy.KEK, c.Keys.KEK.Description)
+	if err != nil {
+		return err
+	}
+
+	err = k.CreateKey(BackendType(c.Keys.Db.Type), hierarchy.Db, c.Keys.Db.Description)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (k *KeyHierarchy) SaveKey(vfs afero.Fs, hier hierarchy.Hierarchy, keydir string) error {
 	writeFile := func(file string, b []byte) error {
 		if err := vfs.MkdirAll(filepath.Dir(file), os.ModePerm); err != nil {
@@ -154,11 +209,11 @@ func (k *KeyHierarchy) RotateKeyWithBackend(hier hierarchy.Hierarchy, backend Ba
 	var err error
 	switch hier {
 	case hierarchy.PK:
-		k.pk, err = createKey(k.state, string(backend), hier, k.pk.Description())
+		err = k.CreateKey(backend, hier, k.pk.Description())
 	case hierarchy.KEK:
-		k.kek, err = createKey(k.state, string(backend), hier, k.kek.Description())
+		err = k.CreateKey(backend, hier, k.kek.Description())
 	case hierarchy.Db:
-		k.db, err = createKey(k.state, string(backend), hier, k.db.Description())
+		err = k.CreateKey(backend, hier, k.db.Description())
 	}
 	return err
 }
@@ -225,45 +280,6 @@ func (k *KeyHierarchy) SignFile(hier hierarchy.Hierarchy, peBinary *authenticode
 		return nil, err
 	}
 	return peBinary.Bytes(), nil
-}
-
-func createKey(state *config.State, backend string, hier hierarchy.Hierarchy, desc string) (KeyBackend, error) {
-	if desc == "" {
-		desc = hier.Description()
-	}
-	switch backend {
-	case "file", "":
-		return NewFileKey(hier, desc)
-	case "tpm":
-		return NewTPMKey(state.TPM, desc)
-	case "yubikey":
-		return NewYubikeyKey(state.Yubikey, hier)
-	default:
-		return NewFileKey(hier, desc)
-	}
-}
-
-func CreateKeys(state *config.State) (*KeyHierarchy, error) {
-	var hier KeyHierarchy
-	var err error
-
-	c := state.Config
-	hier.pk, err = createKey(state, c.Keys.PK.Type, hierarchy.PK, c.Keys.PK.Description)
-	if err != nil {
-		return nil, err
-	}
-
-	hier.kek, err = createKey(state, c.Keys.KEK.Type, hierarchy.KEK, c.Keys.KEK.Description)
-	if err != nil {
-		return nil, err
-	}
-
-	hier.db, err = createKey(state, c.Keys.Db.Type, hierarchy.Db, c.Keys.Db.Description)
-	if err != nil {
-		return nil, err
-	}
-
-	return &hier, nil
 }
 
 func readKey(state *config.State, keydir string, kc *config.KeyConfig, hier hierarchy.Hierarchy) (KeyBackend, error) {

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -21,11 +21,15 @@ func TestCreateKeys(t *testing.T) {
 			Db:  &config.KeyConfig{},
 		},
 	}
+
 	state := &config.State{
 		Fs:     afero.NewOsFs(),
 		Config: c,
 	}
-	hier, err := CreateKeys(state)
+
+	hier := NewKeyHierarchy(state)
+
+	err := hier.CreateKeys()
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -39,7 +39,7 @@ func TestCreateKeys(t *testing.T) {
 		t.Fatalf("%v", err)
 	}
 
-	key, err := GetKeyBackend(state, hierarchy.PK)
+	key, err := hier.ReadKey(hierarchy.PK)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -72,20 +72,19 @@ func RunCreateKeys(state *config.State) error {
 	}
 
 	// Should be own flag type
-	if createKeysCmdOptions.Keytype != "" && (createKeysCmdOptions.Keytype == "file" || createKeysCmdOptions.Keytype == "tpm" || createKeysCmdOptions.Keytype == "yubikey") {
+	if createKeysCmdOptions.Keytype != "" {
 		state.Config.Keys.PK.Type = createKeysCmdOptions.Keytype
 		state.Config.Keys.KEK.Type = createKeysCmdOptions.Keytype
 		state.Config.Keys.Db.Type = createKeysCmdOptions.Keytype
-	} else {
-		if createKeysCmdOptions.PKKeytype != "" && (createKeysCmdOptions.PKKeytype == "file" || createKeysCmdOptions.PKKeytype == "tpm" || createKeysCmdOptions.PKKeytype == "yubikey") {
-			state.Config.Keys.PK.Type = createKeysCmdOptions.PKKeytype
-		}
-		if createKeysCmdOptions.KEKKeytype != "" && (createKeysCmdOptions.KEKKeytype == "file" || createKeysCmdOptions.KEKKeytype == "tpm" || createKeysCmdOptions.KEKKeytype == "yubikey") {
-			state.Config.Keys.KEK.Type = createKeysCmdOptions.KEKKeytype
-		}
-		if createKeysCmdOptions.DbKeytype != "" && (createKeysCmdOptions.DbKeytype == "file" || createKeysCmdOptions.DbKeytype == "tpm" || createKeysCmdOptions.DbKeytype == "yubikey") {
-			state.Config.Keys.Db.Type = createKeysCmdOptions.DbKeytype
-		}
+	}
+	if createKeysCmdOptions.PKKeytype != "" {
+		state.Config.Keys.PK.Type = createKeysCmdOptions.PKKeytype
+	}
+	if createKeysCmdOptions.KEKKeytype != "" {
+		state.Config.Keys.KEK.Type = createKeysCmdOptions.KEKKeytype
+	}
+	if createKeysCmdOptions.DbKeytype != "" {
+		state.Config.Keys.Db.Type = createKeysCmdOptions.DbKeytype
 	}
 
 	// if any keytype is yubikey close it appropriately at the end
@@ -167,7 +166,7 @@ func createKeysCmdFlags(cmd *cobra.Command) {
 	f.BoolVar(&createKeysCmdOptions.OverwriteYubikey, "yk-overwrite", false, "overwrite existing key if it exists in the Yubikey Signature slot")
 	f.StringVarP(&createKeysCmdOptions.exportPath, "export", "e", "", "export file path")
 	f.StringVarP(&createKeysCmdOptions.databasePath, "database-path", "d", "", "location to create GUID file")
-	f.StringVarP(&createKeysCmdOptions.Keytype, "keytype", "", "", "key type for all keys")
+	f.StringVarP(&createKeysCmdOptions.Keytype, "keytype", "", "", "key type for all keys (individual types take priority)")
 	f.StringVarP(&createKeysCmdOptions.PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
 	f.StringVarP(&createKeysCmdOptions.KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
 	f.StringVarP(&createKeysCmdOptions.DbKeytype, "db-keytype", "", "", "db key type (default: file)")

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -8,8 +8,10 @@ import (
 	"github.com/foxboron/sbctl"
 	"github.com/foxboron/sbctl/backend"
 	"github.com/foxboron/sbctl/config"
+	"github.com/foxboron/sbctl/hierarchy"
 	"github.com/foxboron/sbctl/logging"
 	"github.com/foxboron/sbctl/lsm"
+	"github.com/foxboron/sbctl/stringset"
 	"github.com/landlock-lsm/go-landlock/landlock"
 	"github.com/spf13/cobra"
 )
@@ -21,12 +23,15 @@ type CreateKeysCmdOptions struct {
 	KEKKeytype       string
 	DbKeytype        string
 	PKKeytype        string
+	Partial          stringset.StringSet
 	OverwriteYubikey bool
 }
 
 var (
-	createKeysCmdOptions = CreateKeysCmdOptions{}
-	createKeysCmd        = &cobra.Command{
+	createKeysCmdOptions = CreateKeysCmdOptions{
+		Partial: stringset.StringSet{Allowed: []string{"PK", "KEK", "db"}},
+	}
+	createKeysCmd = &cobra.Command{
 		Use:   "create-keys",
 		Short: "Create a set of secure boot signing keys",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -94,27 +99,66 @@ func RunCreateKeys(state *config.State) error {
 	}
 	logging.Print("Created Owner UUID %s\n", uuid)
 
-	if sbctl.CheckIfKeysInitialized(state.Fs, state.Config.Keydir) {
-		logging.Ok("Secure boot keys have already been created!")
+	var beType backend.BackendType
+	var hier hierarchy.Hierarchy
+	var desc string
+	kh := backend.NewKeyHierarchy(state)
+
+	switch createKeysCmdOptions.Partial.Value {
+	case "PK":
+		hier = hierarchy.PK
+		beType = backend.BackendType(state.Config.Keys.PK.Type)
+		desc = state.Config.Keys.PK.Description
+
+	case "KEK":
+		hier = hierarchy.KEK
+		beType = backend.BackendType(state.Config.Keys.KEK.Type)
+		desc = state.Config.Keys.KEK.Description
+
+	case "db":
+		hier = hierarchy.Db
+		beType = backend.BackendType(state.Config.Keys.Db.Type)
+		desc = state.Config.Keys.Db.Description
+
+	default:
+		// if no partial flag is given, create all keys
+		if sbctl.CheckIfKeysInitialized(state.Fs, state.Config.Keydir) {
+			logging.Ok("Secure boot keys have already been created!")
+			return nil
+		}
+
+		err := kh.CreateKeys()
+		if err != nil {
+			logging.NotOk("")
+			return fmt.Errorf("couldn't initialize secure boot: %w", err)
+		}
+		err = kh.SaveKeys(state.Fs, state.Config.Keydir)
+		if err != nil {
+			logging.NotOk("")
+			return fmt.Errorf("couldn't initialize secure boot: %w", err)
+		}
+
+		logging.Ok("")
+		logging.Println("Secure boot keys created!")
 		return nil
 	}
 
-	hier := backend.NewKeyHierarchy(state)
-
-	err = hier.CreateKeys()
-	if err != nil {
-		logging.NotOk("")
-		return fmt.Errorf("couldn't initialize secure boot: %w", err)
+	if sbctl.CheckIfKeyInitialized(state.Fs, state.Config.Keydir, hier) {
+		logging.Ok("%s has already been created!", hier.String())
+		return nil
 	}
 
-	err = hier.SaveKeys(state.Fs, state.Config.Keydir)
+	err = kh.CreateKey(beType, hier, desc)
 	if err != nil {
-		logging.NotOk("")
-		return fmt.Errorf("couldn't initialize secure boot: %w", err)
+		return fmt.Errorf("couldn't initialize %s: %w", hier.String(), err)
+	}
+	err = kh.SaveKey(state.Fs, hier, state.Config.Keydir)
+	if err != nil {
+		return fmt.Errorf("couldn't initialize %s: %w", hier.String(), err)
 	}
 
 	logging.Ok("")
-	logging.Println("Secure boot keys created!")
+	logging.Print("%s created!\n", hier.String())
 	return nil
 }
 
@@ -127,6 +171,7 @@ func createKeysCmdFlags(cmd *cobra.Command) {
 	f.StringVarP(&createKeysCmdOptions.PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
 	f.StringVarP(&createKeysCmdOptions.KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
 	f.StringVarP(&createKeysCmdOptions.DbKeytype, "db-keytype", "", "", "db key type (default: file)")
+	f.VarPF(&createKeysCmdOptions.Partial, "partial", "p", "create a partial set of keys")
 }
 
 func init() {

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
+type CreateKeysCmdOptions struct {
 	exportPath       string
 	databasePath     string
 	Keytype          string
@@ -22,16 +22,19 @@ var (
 	DbKeytype        string
 	PKKeytype        string
 	OverwriteYubikey bool
-)
-
-var createKeysCmd = &cobra.Command{
-	Use:   "create-keys",
-	Short: "Create a set of secure boot signing keys",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		state := cmd.Context().Value(stateDataKey{}).(*config.State)
-		return RunCreateKeys(state)
-	},
 }
+
+var (
+	createKeysCmdOptions = CreateKeysCmdOptions{}
+	createKeysCmd        = &cobra.Command{
+		Use:   "create-keys",
+		Short: "Create a set of secure boot signing keys",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			state := cmd.Context().Value(stateDataKey{}).(*config.State)
+			return RunCreateKeys(state)
+		},
+	}
+)
 
 func RunCreateKeys(state *config.State) error {
 	if state.Config.Landlock {
@@ -43,15 +46,15 @@ func RunCreateKeys(state *config.State) error {
 		}
 	}
 	// Overrides keydir or GUID location
-	if exportPath != "" {
-		state.Config.Keydir = exportPath
+	if createKeysCmdOptions.exportPath != "" {
+		state.Config.Keydir = createKeysCmdOptions.exportPath
 	}
 
-	if databasePath != "" {
-		state.Config.GUID = databasePath
+	if createKeysCmdOptions.databasePath != "" {
+		state.Config.GUID = createKeysCmdOptions.databasePath
 	}
 
-	if OverwriteYubikey {
+	if createKeysCmdOptions.OverwriteYubikey {
 		logging.Warn("Overwriting Yubikey option enabled")
 		state.Yubikey.Overwrite = true
 	}
@@ -64,24 +67,24 @@ func RunCreateKeys(state *config.State) error {
 	}
 
 	// Should be own flag type
-	if Keytype != "" && (Keytype == "file" || Keytype == "tpm" || Keytype == "yubikey") {
-		state.Config.Keys.PK.Type = Keytype
-		state.Config.Keys.KEK.Type = Keytype
-		state.Config.Keys.Db.Type = Keytype
+	if createKeysCmdOptions.Keytype != "" && (createKeysCmdOptions.Keytype == "file" || createKeysCmdOptions.Keytype == "tpm" || createKeysCmdOptions.Keytype == "yubikey") {
+		state.Config.Keys.PK.Type = createKeysCmdOptions.Keytype
+		state.Config.Keys.KEK.Type = createKeysCmdOptions.Keytype
+		state.Config.Keys.Db.Type = createKeysCmdOptions.Keytype
 	} else {
-		if PKKeytype != "" && (PKKeytype == "file" || PKKeytype == "tpm" || PKKeytype == "yubikey") {
-			state.Config.Keys.PK.Type = PKKeytype
+		if createKeysCmdOptions.PKKeytype != "" && (createKeysCmdOptions.PKKeytype == "file" || createKeysCmdOptions.PKKeytype == "tpm" || createKeysCmdOptions.PKKeytype == "yubikey") {
+			state.Config.Keys.PK.Type = createKeysCmdOptions.PKKeytype
 		}
-		if KEKKeytype != "" && (KEKKeytype == "file" || KEKKeytype == "tpm" || KEKKeytype == "yubikey") {
-			state.Config.Keys.KEK.Type = KEKKeytype
+		if createKeysCmdOptions.KEKKeytype != "" && (createKeysCmdOptions.KEKKeytype == "file" || createKeysCmdOptions.KEKKeytype == "tpm" || createKeysCmdOptions.KEKKeytype == "yubikey") {
+			state.Config.Keys.KEK.Type = createKeysCmdOptions.KEKKeytype
 		}
-		if DbKeytype != "" && (DbKeytype == "file" || DbKeytype == "tpm" || DbKeytype == "yubikey") {
-			state.Config.Keys.Db.Type = DbKeytype
+		if createKeysCmdOptions.DbKeytype != "" && (createKeysCmdOptions.DbKeytype == "file" || createKeysCmdOptions.DbKeytype == "tpm" || createKeysCmdOptions.DbKeytype == "yubikey") {
+			state.Config.Keys.Db.Type = createKeysCmdOptions.DbKeytype
 		}
 	}
 
 	// if any keytype is yubikey close it appropriately at the end
-	if Keytype == "yubikey" || PKKeytype == "yubikey" || KEKKeytype == "yubikey" || DbKeytype == "yubikey" {
+	if createKeysCmdOptions.Keytype == "yubikey" || createKeysCmdOptions.PKKeytype == "yubikey" || createKeysCmdOptions.KEKKeytype == "yubikey" || createKeysCmdOptions.DbKeytype == "yubikey" {
 		defer state.Yubikey.Close()
 	}
 
@@ -114,13 +117,13 @@ func RunCreateKeys(state *config.State) error {
 
 func createKeysCmdFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
-	f.BoolVar(&OverwriteYubikey, "yk-overwrite", false, "overwrite existing key if it exists in the Yubikey Signature slot")
-	f.StringVarP(&exportPath, "export", "e", "", "export file path")
-	f.StringVarP(&databasePath, "database-path", "d", "", "location to create GUID file")
-	f.StringVarP(&Keytype, "keytype", "", "", "key type for all keys")
-	f.StringVarP(&PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
-	f.StringVarP(&KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
-	f.StringVarP(&DbKeytype, "db-keytype", "", "", "db key type (default: file)")
+	f.BoolVar(&createKeysCmdOptions.OverwriteYubikey, "yk-overwrite", false, "overwrite existing key if it exists in the Yubikey Signature slot")
+	f.StringVarP(&createKeysCmdOptions.exportPath, "export", "e", "", "export file path")
+	f.StringVarP(&createKeysCmdOptions.databasePath, "database-path", "d", "", "location to create GUID file")
+	f.StringVarP(&createKeysCmdOptions.Keytype, "keytype", "", "", "key type for all keys")
+	f.StringVarP(&createKeysCmdOptions.PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
+	f.StringVarP(&createKeysCmdOptions.KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
+	f.StringVarP(&createKeysCmdOptions.DbKeytype, "db-keytype", "", "", "db key type (default: file)")
 }
 
 func init() {

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -92,7 +92,9 @@ func RunCreateKeys(state *config.State) error {
 	logging.Print("Created Owner UUID %s\n", uuid)
 	if !sbctl.CheckIfKeysInitialized(state.Fs, state.Config.Keydir) {
 
-		hier, err := backend.CreateKeys(state)
+		hier := backend.NewKeyHierarchy(state)
+
+		err := hier.CreateKeys()
 		if err != nil {
 			logging.NotOk("")
 			return fmt.Errorf("couldn't initialize secure boot: %w", err)

--- a/cmd/sbctl/create-keys.go
+++ b/cmd/sbctl/create-keys.go
@@ -93,25 +93,28 @@ func RunCreateKeys(state *config.State) error {
 		return err
 	}
 	logging.Print("Created Owner UUID %s\n", uuid)
-	if !sbctl.CheckIfKeysInitialized(state.Fs, state.Config.Keydir) {
 
-		hier := backend.NewKeyHierarchy(state)
-
-		err := hier.CreateKeys()
-		if err != nil {
-			logging.NotOk("")
-			return fmt.Errorf("couldn't initialize secure boot: %w", err)
-		}
-		err = hier.SaveKeys(state.Fs, state.Config.Keydir)
-		if err != nil {
-			logging.NotOk("")
-			return fmt.Errorf("couldn't initialize secure boot: %w", err)
-		}
-		logging.Ok("")
-		logging.Println("Secure boot keys created!")
-	} else {
+	if sbctl.CheckIfKeysInitialized(state.Fs, state.Config.Keydir) {
 		logging.Ok("Secure boot keys have already been created!")
+		return nil
 	}
+
+	hier := backend.NewKeyHierarchy(state)
+
+	err = hier.CreateKeys()
+	if err != nil {
+		logging.NotOk("")
+		return fmt.Errorf("couldn't initialize secure boot: %w", err)
+	}
+
+	err = hier.SaveKeys(state.Fs, state.Config.Keydir)
+	if err != nil {
+		logging.NotOk("")
+		return fmt.Errorf("couldn't initialize secure boot: %w", err)
+	}
+
+	logging.Ok("")
+	logging.Println("Secure boot keys created!")
 	return nil
 }
 

--- a/cmd/sbctl/enroll-keys.go
+++ b/cmd/sbctl/enroll-keys.go
@@ -86,13 +86,21 @@ var (
 
 func SignSiglist(k *backend.KeyHierarchy, e efivar.Efivar, sigdb efivar.Marshallable) ([]byte, error) {
 	var signer backend.KeyBackend
+	var err error
+
 	switch e {
 	case efivar.PK:
-		signer = k.GetKeyBackend(efivar.PK)
+		if signer, err = k.GetKeyBackend(efivar.PK); err != nil {
+			return nil, err
+		}
 	case efivar.KEK:
-		signer = k.GetKeyBackend(efivar.PK)
+		if signer, err = k.GetKeyBackend(efivar.PK); err != nil {
+			return nil, err
+		}
 	case efivar.Db:
-		signer = k.GetKeyBackend(efivar.KEK)
+		if signer, err = k.GetKeyBackend(efivar.KEK); err != nil {
+			return nil, err
+		}
 	}
 	_, em, err := signature.SignEFIVariable(e, sigdb, signer.Signer(), signer.Certificate())
 	if err != nil {
@@ -124,15 +132,30 @@ func KeySync(state *config.State, oems []string) error {
 		}
 	}
 
-	if err = efistate.Db.Append(signature.CERT_X509_GUID, *guid, kh.Db.CertificateBytes()); err != nil {
+	kb, err := kh.GetKeyBackend(efivar.Db)
+	if err != nil {
 		return err
 	}
 
-	if err = efistate.KEK.Append(signature.CERT_X509_GUID, *guid, kh.KEK.CertificateBytes()); err != nil {
+	if err = efistate.Db.Append(signature.CERT_X509_GUID, *guid, kb.CertificateBytes()); err != nil {
 		return err
 	}
 
-	if err = efistate.PK.Append(signature.CERT_X509_GUID, *guid, kh.PK.CertificateBytes()); err != nil {
+	kb, err = kh.GetKeyBackend(efivar.KEK)
+	if err != nil {
+		return err
+	}
+
+	if err = efistate.KEK.Append(signature.CERT_X509_GUID, *guid, kb.CertificateBytes()); err != nil {
+		return err
+	}
+
+	kb, err = kh.GetKeyBackend(efivar.PK)
+	if err != nil {
+		return err
+	}
+
+	if err = efistate.PK.Append(signature.CERT_X509_GUID, *guid, kb.CertificateBytes()); err != nil {
 		return err
 	}
 

--- a/cmd/sbctl/enroll-keys.go
+++ b/cmd/sbctl/enroll-keys.go
@@ -111,10 +111,7 @@ func SignSiglist(k *backend.KeyHierarchy, e efivar.Efivar, sigdb efivar.Marshall
 
 // Sync keys from a key directory into efivarfs
 func KeySync(state *config.State, oems []string) error {
-	kh, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return err
-	}
+	kh := backend.NewKeyHierarchy(state)
 
 	guid, err := state.Config.GetGUID(state.Fs)
 	if err != nil {

--- a/cmd/sbctl/generate-bundles.go
+++ b/cmd/sbctl/generate-bundles.go
@@ -38,10 +38,7 @@ var generateBundlesCmd = &cobra.Command{
 			logging.Print("Wrote EFI bundle %s\n", bundle.Output)
 			if sign {
 				file := bundle.Output
-				kh, err := backend.GetKeyHierarchy(state.Fs, state)
-				if err != nil {
-					return err
-				}
+				kh := backend.NewKeyHierarchy(state)
 				err = sbctl.SignFile(state, kh, hierarchy.Db, file, file)
 				if errors.Is(err, sbctl.ErrAlreadySigned) {
 					logging.Unknown("Bundle has already been signed")

--- a/cmd/sbctl/list-bundles.go
+++ b/cmd/sbctl/list-bundles.go
@@ -38,10 +38,7 @@ var listBundlesCmd = &cobra.Command{
 		var isSigned bool
 		err := sbctl.BundleIter(state,
 			func(s *sbctl.Bundle) error {
-				kh, err := backend.GetKeyHierarchy(state.Fs, state)
-				if err != nil {
-					return err
-				}
+				kh := backend.NewKeyHierarchy(state)
 				ok, err := sbctl.VerifyFile(state, kh, hierarchy.Db, s.Output)
 				if err != nil {
 					logging.Error(fmt.Errorf("%s: %w", s.Output, err))

--- a/cmd/sbctl/list-files.go
+++ b/cmd/sbctl/list-files.go
@@ -43,10 +43,7 @@ func RunList(cmd *cobra.Command, args []string) error {
 	var isSigned bool
 	err := sbctl.SigningEntryIter(state,
 		func(s *sbctl.SigningEntry) error {
-			kh, err := backend.GetKeyHierarchy(state.Fs, state)
-			if err != nil {
-				return err
-			}
+			kh := backend.NewKeyHierarchy(state)
 			ok, err := sbctl.VerifyFile(state, kh, hierarchy.Db, s.OutputFile)
 			if err != nil {
 				logging.Error(fmt.Errorf("%s: %w", s.OutputFile, err))

--- a/cmd/sbctl/reset.go
+++ b/cmd/sbctl/reset.go
@@ -135,10 +135,7 @@ func resetDatabase(state *config.State, ev efivar.Efivar, certPaths ...string) e
 		}
 	}
 
-	kh, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return err
-	}
+	kh := backend.NewKeyHierarchy(state)
 
 	switch ev {
 	case efivar.PK:

--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -300,7 +300,7 @@ func rotateKey(state *config.State, hiera string, keyPath, certPath string) erro
 		if err != nil {
 			return fmt.Errorf("could not rotate PK: %v", err)
 		}
-		newKH.PK = bk
+		newKH.UpdateKeyBackend(bk, hierarchy.PK)
 		if err := rotateCerts(state, hierarchy.PK, oldKH, newKH, efistate); err != nil {
 			return fmt.Errorf("could not rotate PK: %v", err)
 		}
@@ -309,7 +309,7 @@ func rotateKey(state *config.State, hiera string, keyPath, certPath string) erro
 		if err != nil {
 			return fmt.Errorf("could not rotate KEK: %v", err)
 		}
-		newKH.KEK = bk
+		newKH.UpdateKeyBackend(bk, hierarchy.KEK)
 		if err := rotateCerts(state, hierarchy.KEK, oldKH, newKH, efistate); err != nil {
 			return fmt.Errorf("could not rotate KEK: %v", err)
 		}
@@ -318,7 +318,7 @@ func rotateKey(state *config.State, hiera string, keyPath, certPath string) erro
 		if err != nil {
 			return fmt.Errorf("could not rotate db: %v", err)
 		}
-		newKH.Db = bk
+		newKH.UpdateKeyBackend(bk, hierarchy.Db)
 		if err := rotateCerts(state, hierarchy.Db, oldKH, newKH, efistate); err != nil {
 			return fmt.Errorf("could not rotate db: %v", err)
 		}

--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -211,7 +211,7 @@ func rotateAllKeys(state *config.State, backupDir, newKeysDir string) error {
 
 	} else {
 		logging.Print("Importing new secure boot keys from %s...", newKeysDir)
-		newKeyHierarchy, err = backend.ImportKeys(newKeysDir)
+		err = newKeyHierarchy.ImportKeys(newKeysDir)
 		if err != nil {
 			logging.NotOk("")
 			return fmt.Errorf("couldn't import secure boot keys: %w", err)

--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -154,10 +154,7 @@ func RunRotateKeys(cmd *cobra.Command, args []string) error {
 }
 
 func rotateAllKeys(state *config.State, backupDir, newKeysDir string) error {
-	oldKeys, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return fmt.Errorf("can't read old keys from dir: %v", err)
-	}
+	oldKeys := backend.NewKeyHierarchy(state)
 
 	efistate, err := sbctl.SystemEFIVariables(state.Efivarfs)
 	if err != nil {
@@ -259,10 +256,7 @@ func rotateKey(state *config.State, hiera string, keyPath, certPath string) erro
 		return fmt.Errorf("a new certificate needs to be provided for a partial reset of %s", hiera)
 	}
 
-	oldKH, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return fmt.Errorf("can't read old keys from dir: %v", err)
-	}
+	oldKH := backend.NewKeyHierarchy(state)
 
 	newCert, err := fs.ReadFile(state.Fs, certPath)
 	if err != nil {
@@ -275,10 +269,7 @@ func rotateKey(state *config.State, hiera string, keyPath, certPath string) erro
 	}
 
 	// We will mutate this to the new state
-	newKH, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return fmt.Errorf("can't read old keys from dir: %v", err)
-	}
+	newKH := backend.NewKeyHierarchy(state)
 
 	efistate, err := sbctl.SystemEFIVariables(state.Efivarfs)
 	if err != nil {

--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -176,20 +176,19 @@ func rotateAllKeys(state *config.State, backupDir, newKeysDir string) error {
 
 	// Should be own flag type, and deduplicated
 	// It should be fine to modify the state here?
-	if rotateKeysCmdOptions.Keytype != "" && (rotateKeysCmdOptions.Keytype == "file" || rotateKeysCmdOptions.Keytype == "tpm") {
+	if rotateKeysCmdOptions.Keytype != "" {
 		state.Config.Keys.PK.Type = rotateKeysCmdOptions.Keytype
 		state.Config.Keys.KEK.Type = rotateKeysCmdOptions.Keytype
 		state.Config.Keys.Db.Type = rotateKeysCmdOptions.Keytype
-	} else {
-		if rotateKeysCmdOptions.PKKeytype != "" && (rotateKeysCmdOptions.PKKeytype == "file" || rotateKeysCmdOptions.PKKeytype == "tpm") {
-			state.Config.Keys.PK.Type = rotateKeysCmdOptions.PKKeytype
-		}
-		if rotateKeysCmdOptions.KEKKeytype != "" && (rotateKeysCmdOptions.KEKKeytype == "file" || rotateKeysCmdOptions.KEKKeytype == "tpm") {
-			state.Config.Keys.KEK.Type = rotateKeysCmdOptions.KEKKeytype
-		}
-		if rotateKeysCmdOptions.DbKeytype != "" && (rotateKeysCmdOptions.DbKeytype == "file" || rotateKeysCmdOptions.DbKeytype == "tpm") {
-			state.Config.Keys.Db.Type = rotateKeysCmdOptions.DbKeytype
-		}
+	}
+	if rotateKeysCmdOptions.PKKeytype != "" {
+		state.Config.Keys.PK.Type = rotateKeysCmdOptions.PKKeytype
+	}
+	if rotateKeysCmdOptions.KEKKeytype != "" {
+		state.Config.Keys.KEK.Type = rotateKeysCmdOptions.KEKKeytype
+	}
+	if rotateKeysCmdOptions.DbKeytype != "" {
+		state.Config.Keys.Db.Type = rotateKeysCmdOptions.DbKeytype
 	}
 
 	newKeyHierarchy := backend.NewKeyHierarchy(state)
@@ -278,20 +277,19 @@ func rotateKey(state *config.State, hiera string, keyPath, certPath string) erro
 
 	// Should be own flag type, and deduplicated
 	// It should be fine to modify the state here?
-	if rotateKeysCmdOptions.Keytype != "" && (rotateKeysCmdOptions.Keytype == "file" || rotateKeysCmdOptions.Keytype == "tpm") {
+	if rotateKeysCmdOptions.Keytype != "" {
 		state.Config.Keys.PK.Type = rotateKeysCmdOptions.Keytype
 		state.Config.Keys.KEK.Type = rotateKeysCmdOptions.Keytype
 		state.Config.Keys.Db.Type = rotateKeysCmdOptions.Keytype
-	} else {
-		if rotateKeysCmdOptions.PKKeytype != "" && (rotateKeysCmdOptions.PKKeytype == "file" || rotateKeysCmdOptions.PKKeytype == "tpm") {
-			state.Config.Keys.PK.Type = rotateKeysCmdOptions.PKKeytype
-		}
-		if rotateKeysCmdOptions.KEKKeytype != "" && (rotateKeysCmdOptions.KEKKeytype == "file" || rotateKeysCmdOptions.KEKKeytype == "tpm") {
-			state.Config.Keys.KEK.Type = rotateKeysCmdOptions.KEKKeytype
-		}
-		if rotateKeysCmdOptions.DbKeytype != "" && (rotateKeysCmdOptions.DbKeytype == "file" || rotateKeysCmdOptions.DbKeytype == "tpm") {
-			state.Config.Keys.Db.Type = rotateKeysCmdOptions.DbKeytype
-		}
+	}
+	if rotateKeysCmdOptions.PKKeytype != "" {
+		state.Config.Keys.PK.Type = rotateKeysCmdOptions.PKKeytype
+	}
+	if rotateKeysCmdOptions.KEKKeytype != "" {
+		state.Config.Keys.KEK.Type = rotateKeysCmdOptions.KEKKeytype
+	}
+	if rotateKeysCmdOptions.DbKeytype != "" {
+		state.Config.Keys.Db.Type = rotateKeysCmdOptions.DbKeytype
 	}
 
 	switch hiera {
@@ -341,7 +339,7 @@ func rotateKeysCmdFlags(cmd *cobra.Command) {
 	f.StringVarP(&rotateKeysCmdOptions.KeyFile, "key-file", "k", "", "key file to replace (only with partial flag)")
 	f.StringVarP(&rotateKeysCmdOptions.CertFile, "cert-file", "c", "", "certificate file to replace (only with partial flag)")
 
-	f.StringVarP(&rotateKeysCmdOptions.Keytype, "keytype", "", "", "key type for all keys")
+	f.StringVarP(&rotateKeysCmdOptions.Keytype, "keytype", "", "", "key type for all keys (individual types take priority)")
 	f.StringVarP(&rotateKeysCmdOptions.PKKeytype, "pk-keytype", "", "", "PK key type (default: file)")
 	f.StringVarP(&rotateKeysCmdOptions.KEKKeytype, "kek-keytype", "", "", "KEK key type (default: file)")
 	f.StringVarP(&rotateKeysCmdOptions.DbKeytype, "db-keytype", "", "", "db key type (default: file)")

--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/foxboron/go-uefi/efi/signature"
+	"github.com/foxboron/go-uefi/efivar"
 	"github.com/foxboron/sbctl"
 	"github.com/foxboron/sbctl/backend"
 	"github.com/foxboron/sbctl/config"
@@ -56,35 +57,63 @@ func rotateCerts(state *config.State, hier hierarchy.Hierarchy, oldkeys *backend
 	case hierarchy.PK:
 		// fmt.Printf("Old PK: %s\n", oldkeys.PK.Certificate().SerialNumber.String())
 		// fmt.Printf("New PK: %s\n", newkeys.PK.Certificate().SerialNumber.String())
-		cert := oldkeys.PK.Certificate().Raw
+
+		kb, err := oldkeys.GetKeyBackend(efivar.PK)
+		if err != nil {
+			return err
+		}
+		cert := kb.Certificate().Raw
 		if efistate.PK.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: cert}) {
 			if err := efistate.PK.Remove(signature.CERT_X509_GUID, *guid, cert); err != nil {
 				return fmt.Errorf("can't remove old key from PK siglist: %v", err)
 			}
 		}
-		efistate.PK.Append(signature.CERT_X509_GUID, *guid, newkeys.PK.CertificateBytes())
+		kb, err = newkeys.GetKeyBackend(efivar.PK)
+		if err != nil {
+			return err
+		}
+		newCertBytes := kb.CertificateBytes()
+		efistate.PK.Append(signature.CERT_X509_GUID, *guid, newCertBytes)
 		return efistate.EnrollKey(hier.Efivar(), oldkeys)
 	case hierarchy.KEK:
 		// fmt.Printf("Old KEK: %s\n", oldkeys.KEK.Certificate().SerialNumber.String())
 		// fmt.Printf("New KEK: %s\n", newkeys.KEK.Certificate().SerialNumber.String())
-		cert := oldkeys.KEK.Certificate().Raw
+		kb, err := oldkeys.GetKeyBackend(efivar.KEK)
+		if err != nil {
+			return err
+		}
+		cert := kb.Certificate().Raw
 		if efistate.KEK.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: cert}) {
 			if err := efistate.KEK.Remove(signature.CERT_X509_GUID, *guid, cert); err != nil {
 				return fmt.Errorf("can't remove old key from KEK siglist: %v", err)
 			}
 		}
-		efistate.KEK.Append(signature.CERT_X509_GUID, *guid, newkeys.KEK.CertificateBytes())
+		kb, err = newkeys.GetKeyBackend(efivar.KEK)
+		if err != nil {
+			return err
+		}
+		newCertBytes := kb.CertificateBytes()
+		efistate.KEK.Append(signature.CERT_X509_GUID, *guid, newCertBytes)
 		return efistate.EnrollKey(hier.Efivar(), newkeys)
 	case hierarchy.Db:
 		// fmt.Printf("Old Db: %s\n", oldkeys.Db.Certificate().SerialNumber.String())
 		// fmt.Printf("New Db: %s\n", newkeys.Db.Certificate().SerialNumber.String())
-		cert := oldkeys.Db.Certificate().Raw
+		kb, err := oldkeys.GetKeyBackend(efivar.Db)
+		if err != nil {
+			return err
+		}
+		cert := kb.Certificate().Raw
 		if efistate.Db.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: cert}) {
 			if err := efistate.Db.Remove(signature.CERT_X509_GUID, *guid, cert); err != nil {
 				return fmt.Errorf("can't remove old key from Db siglist: %v", err)
 			}
 		}
-		efistate.Db.Append(signature.CERT_X509_GUID, *guid, newkeys.Db.CertificateBytes())
+		kb, err = newkeys.GetKeyBackend(efivar.Db)
+		if err != nil {
+			return err
+		}
+		newCertBytes := kb.CertificateBytes()
+		efistate.Db.Append(signature.CERT_X509_GUID, *guid, newCertBytes)
 		return efistate.EnrollKey(hier.Efivar(), newkeys)
 	default:
 		return fmt.Errorf("unknown efivar hierarchy")

--- a/cmd/sbctl/rotate-keys.go
+++ b/cmd/sbctl/rotate-keys.go
@@ -192,11 +192,11 @@ func rotateAllKeys(state *config.State, backupDir, newKeysDir string) error {
 		}
 	}
 
-	var newKeyHierarchy *backend.KeyHierarchy
+	newKeyHierarchy := backend.NewKeyHierarchy(state)
 
 	if newKeysDir == "" {
 		logging.Print("Creating secure boot keys...")
-		newKeyHierarchy, err = backend.CreateKeys(state)
+		err = newKeyHierarchy.CreateKeys()
 		if err != nil {
 			logging.NotOk("")
 			return fmt.Errorf("couldn't initialize secure boot: %w", err)

--- a/cmd/sbctl/setup.go
+++ b/cmd/sbctl/setup.go
@@ -51,6 +51,10 @@ func PrintConfig(state *config.State) error {
 		}
 	} else {
 		kh := backend.NewKeyHierarchy(state)
+		err := kh.ReadKeys()
+		if err != nil {
+			return err
+		}
 		state.Config.Keys = kh.GetConfig(state.Config.Keydir)
 		state.Config.DbAdditions = sbctl.GetEnrolledVendorCerts()
 	}

--- a/cmd/sbctl/setup.go
+++ b/cmd/sbctl/setup.go
@@ -50,10 +50,7 @@ func PrintConfig(state *config.State) error {
 			return err
 		}
 	} else {
-		kh, err := backend.GetKeyHierarchy(state.Fs, state)
-		if err != nil {
-			return err
-		}
+		kh := backend.NewKeyHierarchy(state)
 		state.Config.Keys = kh.GetConfig(state.Config.Keydir)
 		state.Config.DbAdditions = sbctl.GetEnrolledVendorCerts()
 	}

--- a/cmd/sbctl/setup_test.go
+++ b/cmd/sbctl/setup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/foxboron/go-uefi/efi/efitest"
 	"github.com/foxboron/go-uefi/efi/signature"
+	"github.com/foxboron/go-uefi/efivar"
 	"github.com/foxboron/go-uefi/efivarfs/testfs"
 	"github.com/foxboron/sbctl"
 	"github.com/foxboron/sbctl/backend"
@@ -89,9 +90,13 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't get db from efivarfs")
 	}
+	kb, err := kh.GetKeyBackend(efivar.Db)
+	if err != nil {
+		t.Error(err)
+	}
 	data := &signature.SignatureData{
 		Owner: *guid,
-		Data:  kh.Db.Certificate().Raw,
+		Data:  kb.Certificate().Raw,
 	}
 	if !sb.SigDataExists(signature.CERT_X509_GUID, data) {
 		t.Fatalf("can't find db cert in efivarfs")
@@ -101,9 +106,13 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't get kek from efivarfs")
 	}
+	kb, err = kh.GetKeyBackend(efivar.KEK)
+	if err != nil {
+		t.Error(err)
+	}
 	data = &signature.SignatureData{
 		Owner: *guid,
-		Data:  kh.KEK.Certificate().Raw,
+		Data:  kb.Certificate().Raw,
 	}
 	if !sb.SigDataExists(signature.CERT_X509_GUID, data) {
 		t.Fatalf("can't find kek cert in efivarfs")
@@ -113,9 +122,13 @@ func TestSetup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't get pk from efivarfs")
 	}
+	kb, err = kh.GetKeyBackend(efivar.PK)
+	if err != nil {
+		t.Error(err)
+	}
 	data = &signature.SignatureData{
 		Owner: *guid,
-		Data:  kh.PK.Certificate().Raw,
+		Data:  kb.Certificate().Raw,
 	}
 	if !sb.SigDataExists(signature.CERT_X509_GUID, data) {
 		t.Fatalf("can't find pk cert in efivarfs")
@@ -201,9 +214,13 @@ func TestSetupTPMKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't get db from efivarfs")
 	}
+	kb, err := kh.GetKeyBackend(efivar.Db)
+	if err != nil {
+		t.Error(err)
+	}
 	data := &signature.SignatureData{
 		Owner: *guid,
-		Data:  kh.Db.Certificate().Raw,
+		Data:  kb.Certificate().Raw,
 	}
 	if !sb.SigDataExists(signature.CERT_X509_GUID, data) {
 		t.Fatalf("can't find db cert in efivarfs")
@@ -213,9 +230,13 @@ func TestSetupTPMKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't get kek from efivarfs")
 	}
+	kb, err = kh.GetKeyBackend(efivar.KEK)
+	if err != nil {
+		t.Error(err)
+	}
 	data = &signature.SignatureData{
 		Owner: *guid,
-		Data:  kh.KEK.Certificate().Raw,
+		Data:  kb.Certificate().Raw,
 	}
 	if !sb.SigDataExists(signature.CERT_X509_GUID, data) {
 		t.Fatalf("can't find kek cert in efivarfs")
@@ -225,9 +246,13 @@ func TestSetupTPMKeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("can't get pk from efivarfs")
 	}
+	kb, err = kh.GetKeyBackend(efivar.PK)
+	if err != nil {
+		t.Error(err)
+	}
 	data = &signature.SignatureData{
 		Owner: *guid,
-		Data:  kh.PK.Certificate().Raw,
+		Data:  kb.Certificate().Raw,
 	}
 	if !sb.SigDataExists(signature.CERT_X509_GUID, data) {
 		t.Fatalf("can't find pk cert in efivarfs")

--- a/cmd/sbctl/setup_test.go
+++ b/cmd/sbctl/setup_test.go
@@ -69,10 +69,7 @@ func TestSetup(t *testing.T) {
 	}
 
 	// Check that we can sign and verify a file
-	kh, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		t.Fatalf("can't get key hierarchy: %v", err)
-	}
+	kh := backend.NewKeyHierarchy(state)
 	ok, err := sbctl.VerifyFile(state, kh, hierarchy.Db, "/boot/new.efi")
 	if err != nil {
 		t.Fatalf("can't verify file: %v", err)
@@ -193,10 +190,7 @@ func TestSetupTPMKeys(t *testing.T) {
 	}
 
 	// Check that we can sign and verify a file
-	kh, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		t.Fatalf("can't get key hierarchy: %v", err)
-	}
+	kh := backend.NewKeyHierarchy(state)
 	ok, err := sbctl.VerifyFile(state, kh, hierarchy.Db, "/boot/new.efi")
 	if err != nil {
 		t.Fatalf("can't verify file: %v", err)

--- a/cmd/sbctl/sign-all.go
+++ b/cmd/sbctl/sign-all.go
@@ -59,10 +59,7 @@ func SignAll(state *config.State) error {
 	}
 	for _, entry := range files {
 
-		kh, err := backend.GetKeyHierarchy(state.Fs, state)
-		if err != nil {
-			return err
-		}
+		kh := backend.NewKeyHierarchy(state)
 
 		err = sbctl.SignFile(state, kh, hierarchy.Db, entry.File, entry.OutputFile)
 		if errors.Is(err, sbctl.ErrAlreadySigned) {

--- a/cmd/sbctl/sign.go
+++ b/cmd/sbctl/sign.go
@@ -79,10 +79,7 @@ var signCmd = &cobra.Command{
 			}
 		}
 
-		kh, err := backend.GetKeyHierarchy(state.Fs, state)
-		if err != nil {
-			return err
-		}
+		kh := backend.NewKeyHierarchy(state)
 
 		err = sbctl.Sign(state, kh, file, output, save)
 		if errors.Is(err, sbctl.ErrAlreadySigned) {

--- a/cmd/sbctl/status.go
+++ b/cmd/sbctl/status.go
@@ -85,10 +85,7 @@ func PrintStatus(s *Status) {
 }
 
 func RunDebug(state *config.State) error {
-	kh, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return err
-	}
+	kh := backend.NewKeyHierarchy(state)
 
 	efistate, err := sbctl.SystemEFIVariables(state.Efivarfs)
 	if err != nil {

--- a/cmd/sbctl/status.go
+++ b/cmd/sbctl/status.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/foxboron/go-uefi/efi/signature"
+	"github.com/foxboron/go-uefi/efivar"
 	"github.com/foxboron/sbctl"
 	"github.com/foxboron/sbctl/backend"
 	"github.com/foxboron/sbctl/certs"
@@ -99,15 +100,30 @@ func RunDebug(state *config.State) error {
 		return err
 	}
 
-	if efistate.PK.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: kh.PK.Certificate().Raw}) {
+	kb, err := kh.GetKeyBackend(efivar.PK)
+	if err != nil {
+		return err
+	}
+
+	if efistate.PK.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: kb.Certificate().Raw}) {
 		slog.Debug("PK is fine")
 	}
 
-	if efistate.KEK.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: kh.KEK.Certificate().Raw}) {
+	kb, err = kh.GetKeyBackend(efivar.KEK)
+	if err != nil {
+		return err
+	}
+
+	if efistate.KEK.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: kb.Certificate().Raw}) {
 		slog.Debug("KEK is fine")
 	}
 
-	if efistate.Db.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: kh.Db.Certificate().Raw}) {
+	kb, err = kh.GetKeyBackend(efivar.Db)
+	if err != nil {
+		return err
+	}
+
+	if efistate.Db.SigDataExists(signature.CERT_X509_GUID, &signature.SignatureData{Owner: *guid, Data: kb.Certificate().Raw}) {
 		slog.Debug("db is fine")
 	}
 

--- a/cmd/sbctl/verify.go
+++ b/cmd/sbctl/verify.go
@@ -56,10 +56,7 @@ func VerifyOneFile(state *config.State, f string) error {
 		return fmt.Errorf("%s: %w", f, ErrInvalidHeader)
 	}
 
-	kh, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return err
-	}
+	kh := backend.NewKeyHierarchy(state)
 
 	ok, err = sbctl.VerifyFile(state, kh, hierarchy.Db, f)
 	if err != nil {

--- a/keys.go
+++ b/keys.go
@@ -136,7 +136,16 @@ var SecureBootKeys = []struct {
 	// },
 }
 
-// Check if we have already intialized keys in the given output directory
+// CheckIfKeyInitialized checks if the key of given hierarchy is existing in the given output directory
+func CheckIfKeyInitialized(vfs afero.Fs, output string, hier hierarchy.Hierarchy) bool {
+	path := filepath.Join(output, hier.String())
+	if _, err := vfs.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
+}
+
+// CheckIfKeysInitialized checks if all keys are existing in the given output directory
 func CheckIfKeysInitialized(vfs afero.Fs, output string) bool {
 	for _, key := range SecureBootKeys {
 		path := filepath.Join(output, key.Key)

--- a/sbctl.go
+++ b/sbctl.go
@@ -141,10 +141,7 @@ func Sign(state *config.State, keys *backend.KeyHierarchy, file, output string, 
 		}
 	}
 
-	kh, err := backend.GetKeyHierarchy(state.Fs, state)
-	if err != nil {
-		return err
-	}
+	kh := backend.NewKeyHierarchy(state)
 
 	files, err := ReadFileDatabase(state.Fs, state.Config.FilesDb)
 	if err != nil {

--- a/siglist.go
+++ b/siglist.go
@@ -35,13 +35,21 @@ func (e *EFIVariables) GetSiglist(ev efivar.Efivar) *signature.SignatureDatabase
 func (e *EFIVariables) EnrollKey(ev efivar.Efivar, hier *backend.KeyHierarchy) error {
 	// Ensure we are using the correct signer for the backend
 	var signer backend.KeyBackend
+	var err error
+
 	switch ev {
 	case efivar.PK:
-		signer = hier.GetKeyBackend(efivar.PK)
+		if signer, err = hier.GetKeyBackend(efivar.PK); err != nil {
+			return err
+		}
 	case efivar.KEK:
-		signer = hier.GetKeyBackend(efivar.PK)
+		if signer, err = hier.GetKeyBackend(efivar.PK); err != nil {
+			return err
+		}
 	case efivar.Db:
-		signer = hier.GetKeyBackend(efivar.KEK)
+		if signer, err = hier.GetKeyBackend(efivar.KEK); err != nil {
+			return err
+		}
 	}
 	// fmt.Printf("%s is signed by %s\n", ev.Name, signer.Certificate().SerialNumber.String())
 	return e.fs.WriteSignedUpdate(ev, e.GetSiglist(ev), signer.Signer(), signer.Certificate())


### PR DESCRIPTION
While this PR admittedly is rather massive, I tried to split it into digestible commits for easier review.

- The first three commits implement lazy loading of key backends from disk, namely PK, KEK, and db.
This will already close #356.

- The next three commits change the use of `KeyHierarchy` by turning a few functions into struct methods, which better fits the understanding I got from reading the code: after initializing a new object with `NewKeyHierarchy` it can be filled with `ReadKey`, `CreateKey`, or `ImportKey`, and then be used for operations such as sign/verify/save.
Please let me know if you agree with this approach.

- The next three commits prepare and implement partial key generation by adding `--partial` to `sbctl create-keys`
- The last commit simplifies CLI input checks, which I stumbled upon when implementing partial key support when creating keys

